### PR TITLE
Fix NHentai manga details parsing

### DIFF
--- a/src/all/nhentai/build.gradle
+++ b/src/all/nhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NHentai'
     extClass = '.NHFactory'
-    extVersionCode = 57
+    extVersionCode = 58
     isNsfw = true
 }
 

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHDto.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHDto.kt
@@ -21,7 +21,7 @@ class PaginatedResponse<T>(
 @Serializable
 class GalleryItem(
     val id: Int,
-    val thumbnail: String,
+    val thumbnail: String? = null,
     @SerialName("english_title") val englishTitle: String? = null,
     @SerialName("japanese_title") val japaneseTitle: String? = null,
 )
@@ -30,12 +30,15 @@ class GalleryItem(
 class Hentai(
     val id: Int,
     val pages: List<Image> = emptyList(),
-    val thumbnail: Image,
-    val tags: List<Tag>,
-    val title: Title,
-    @SerialName("upload_date") private val uploadDate: Long,
-    @SerialName("num_favorites") val numFavorites: Long,
-    @SerialName("num_pages") val numPages: Int,
+    @SerialName("media_id") val mediaId: String? = null,
+    val cover: Image? = null,
+    val thumbnail: Image? = null,
+    val scanlator: String? = null,
+    val tags: List<Tag> = emptyList(),
+    val title: Title = Title(),
+    @SerialName("upload_date") private val uploadDate: Long = 0,
+    @SerialName("num_favorites") val numFavorites: Long = 0,
+    @SerialName("num_pages") val numPages: Int = 0,
 ) {
     fun toSChapter() = SChapter.create().apply {
         name = "Chapter"
@@ -54,11 +57,60 @@ class Title(
 
 @Serializable
 class Image(
-    val path: String,
+    val path: String? = null,
+    @SerialName("t") val type: String? = null,
+    val width: Long? = null,
+    val height: Long? = null,
+    val thumbnail: String? = null,
 )
 
 @Serializable
 class Tag(
     val name: String,
     val type: String,
+)
+
+@Serializable
+class LegacyHentai(
+    val id: Int,
+    @SerialName("media_id") val mediaId: String? = null,
+    val images: LegacyImages = LegacyImages(),
+    val tags: List<Tag> = emptyList(),
+    val title: Title = Title(),
+    @SerialName("upload_date") val uploadDate: Long = 0,
+    @SerialName("num_favorites") val numFavorites: Long = 0,
+)
+
+@Serializable
+class LegacyImages(
+    val pages: List<Image> = emptyList(),
+    val cover: Image? = null,
+    val thumbnail: Image? = null,
+)
+
+@Serializable
+class CompatGalleryResponse(
+    val id: Int,
+    @SerialName("media_id") val mediaId: String? = null,
+    val title: Title = Title(),
+    val images: CompatImages = CompatImages(),
+    val scanlator: String? = null,
+    @SerialName("upload_date") val uploadDate: Long = 0,
+    val tags: List<Tag> = emptyList(),
+    @SerialName("num_pages") val numPages: Int = 0,
+    @SerialName("num_favorites") val numFavorites: Long = 0,
+)
+
+@Serializable
+class CompatImages(
+    val pages: List<CompatImage> = emptyList(),
+    val cover: CompatImage? = null,
+    val thumbnail: CompatImage? = null,
+)
+
+@Serializable
+class CompatImage(
+    @SerialName("t") val type: String? = null,
+    @SerialName("w") val width: Long? = null,
+    @SerialName("h") val height: Long? = null,
 )

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHUtils.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHUtils.kt
@@ -1,9 +1,9 @@
 package eu.kanade.tachiyomi.extension.all.nhentai
 
 object NHUtils {
-    fun getArtists(data: Hentai): String {
+    fun getArtists(data: Hentai): String? {
         val artists = data.tags.filter { it.type == "artist" }
-        return artists.joinToString { it.name }
+        return artists.joinToString { it.name }.takeIf { it.isNotBlank() }
     }
 
     fun getGroups(data: Hentai): String? {

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
@@ -62,6 +62,8 @@ open class NHentai(
     override val client: OkHttpClient by lazy {
         network.cloudflareClient.newBuilder()
             .rateLimit(4)
+            // TachiyomiSY 1.12.0 still expects the legacy `window._gallery = JSON.parse(...)` payload
+            // in its delegated NHentai metadata parser, even though the site now returns API JSON.
             .addInterceptor(::galleryDetailsCompatInterceptor)
             .addNetworkInterceptor(::authorizationInterceptor)
             .build()
@@ -123,53 +125,18 @@ open class NHentai(
             .removeHeader(DETAILS_COMPAT_HEADER)
             .build()
 
-        return try {
-            val apiResponse = chain.proceed(cleanRequest)
+        return chain.proceed(cleanRequest).use { apiResponse ->
+            val contentType = apiResponse.body.contentType()
             val apiBody = apiResponse.body.string()
-            val data = apiBody.parseAs<Hentai>(json)
-            val compatPayload = CompatGalleryResponse(
-                id = data.id,
-                mediaId = data.mediaId,
-                title = data.title,
-                images = CompatImages(
-                    pages = data.pages.map { page ->
-                        CompatImage(
-                            type = pathToLegacyType(page.path),
-                            width = page.width,
-                            height = page.height,
-                        )
-                    },
-                    cover = CompatImage(
-                        type = pathToLegacyType(data.cover?.path),
-                        width = data.cover?.width,
-                        height = data.cover?.height,
-                    ),
-                    thumbnail = CompatImage(
-                        type = pathToLegacyType(data.thumbnail?.path),
-                        width = data.thumbnail?.width,
-                        height = data.thumbnail?.height,
-                    ),
-                ),
-                scanlator = data.scanlator.nullIfBlank(),
-                uploadDate = data.toSChapter().date_upload / 1000,
-                tags = data.tags,
-                numPages = data.numPages.takeIf { it > 0 } ?: data.pages.size,
-                numFavorites = data.numFavorites,
-            )
-            val compatJson = json.encodeToString(compatPayload)
-            val escapedBody = compatJson
-                .replace("\\", "\\u005c")
-                .replace("\"", "\\u0022")
-                .replace("\n", "\\u000a")
-                .replace("\r", "\\u000d")
-                .replace("\t", "\\u0009")
-            val legacyBody = """window._gallery = JSON.parse("$escapedBody");"""
+            val responseBody = if (apiResponse.isSuccessful) {
+                buildCompatGalleryBody(apiBody)
+            } else {
+                apiBody
+            }
             apiResponse.newBuilder()
                 .request(cleanRequest)
-                .body(legacyBody.toResponseBody(apiResponse.body.contentType()))
+                .body(responseBody.toResponseBody(contentType))
                 .build()
-        } catch (e: Exception) {
-            chain.proceed(cleanRequest)
         }
     }
 
@@ -200,11 +167,51 @@ open class NHentai(
     }
 
     private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
-    private val galleryJsonRegex = Regex(""".parse\("(.*)"\);""")
+    private val galleryJsonRegex = Regex(""".parse\("(.*?)"\);""", setOf(RegexOption.DOT_MATCHES_ALL))
     private val unicodeEscapeRegex = Regex("""\\u([0-9a-fA-F]{4})""")
     private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()
     private fun String?.nullIfBlank() = this?.trim()?.takeIf { it.isNotEmpty() }
     private fun fallbackTitle(id: Int) = "Gallery #$id"
+    private fun buildCompatGalleryBody(apiBody: String): String {
+        val data = apiBody.parseAs<Hentai>(json)
+        val compatPayload = CompatGalleryResponse(
+            id = data.id,
+            mediaId = data.mediaId,
+            title = data.title,
+            images = CompatImages(
+                pages = data.pages.map { page ->
+                    CompatImage(
+                        type = pathToLegacyType(page.path),
+                        width = page.width,
+                        height = page.height,
+                    )
+                },
+                cover = CompatImage(
+                    type = pathToLegacyType(data.cover?.path),
+                    width = data.cover?.width,
+                    height = data.cover?.height,
+                ),
+                thumbnail = CompatImage(
+                    type = pathToLegacyType(data.thumbnail?.path),
+                    width = data.thumbnail?.width,
+                    height = data.thumbnail?.height,
+                ),
+            ),
+            scanlator = data.scanlator.nullIfBlank(),
+            uploadDate = data.toSChapter().date_upload / 1000,
+            tags = data.tags,
+            numPages = data.numPages.takeIf { it > 0 } ?: data.pages.size,
+            numFavorites = data.numFavorites,
+        )
+        val compatJson = json.encodeToString(compatPayload)
+        val escapedBody = compatJson
+            .replace("\\", "\\u005c")
+            .replace("\"", "\\u0022")
+            .replace("\n", "\\u000a")
+            .replace("\r", "\\u000d")
+            .replace("\t", "\\u0009")
+        return """window._gallery = JSON.parse("$escapedBody");"""
+    }
     private fun String.decodeHtmlGalleryJson(): String {
         val galleryJson = galleryJsonRegex.find(this)?.groupValues?.getOrNull(1)
             ?: throw IOException("Unable to locate embedded gallery JSON")
@@ -448,25 +455,13 @@ open class NHentai(
             ?: englishTitle?.shortenTitle()
             ?: japaneseTitle?.shortenTitle()
             ?: fullTitle
-        val artists = getArtists(
-            Hentai(
-                id = data.id,
-                tags = data.tags,
-                title = data.title,
-            ),
-        )
-        val groups = getGroups(
-            Hentai(
-                id = data.id,
-                tags = data.tags,
-                title = data.title,
-            ),
-        )
         val tagData = Hentai(
             id = data.id,
             tags = data.tags,
             title = data.title,
         )
+        val artists = getArtists(tagData)
+        val groups = getGroups(tagData)
         val thumbnailPath = data.thumbnailPath ?: data.coverPath
 
         return SManga.create().apply {
@@ -513,9 +508,11 @@ open class NHentai(
 
     override fun pageListParse(response: Response): List<Page> {
         val data = response.parseAs<Hentai>(json)
-        return data.pages.mapIndexedNotNull { i, page ->
-            page.path?.let { Page(i, imageUrl = "$imageServer/$it") }
-        }
+        return data.pages
+            .mapNotNull { it.path }
+            .mapIndexed { i, path ->
+                Page(i, imageUrl = "$imageServer/$path")
+            }
     }
 
     override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()

--- a/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
+++ b/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHentai.kt
@@ -26,12 +26,14 @@ import keiyoushi.lib.randomua.setRandomUserAgent
 import keiyoushi.utils.firstInstanceOrNull
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import uy.kohesive.injekt.injectLazy
 import java.io.IOException
 
@@ -60,6 +62,7 @@ open class NHentai(
     override val client: OkHttpClient by lazy {
         network.cloudflareClient.newBuilder()
             .rateLimit(4)
+            .addInterceptor(::galleryDetailsCompatInterceptor)
             .addNetworkInterceptor(::authorizationInterceptor)
             .build()
     }
@@ -109,6 +112,67 @@ open class NHentai(
         return response
     }
 
+    private fun galleryDetailsCompatInterceptor(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val requiresCompatBody = request.header(DETAILS_COMPAT_HEADER) == "1"
+        if (!requiresCompatBody) {
+            return chain.proceed(request)
+        }
+
+        val cleanRequest = request.newBuilder()
+            .removeHeader(DETAILS_COMPAT_HEADER)
+            .build()
+
+        return try {
+            val apiResponse = chain.proceed(cleanRequest)
+            val apiBody = apiResponse.body.string()
+            val data = apiBody.parseAs<Hentai>(json)
+            val compatPayload = CompatGalleryResponse(
+                id = data.id,
+                mediaId = data.mediaId,
+                title = data.title,
+                images = CompatImages(
+                    pages = data.pages.map { page ->
+                        CompatImage(
+                            type = pathToLegacyType(page.path),
+                            width = page.width,
+                            height = page.height,
+                        )
+                    },
+                    cover = CompatImage(
+                        type = pathToLegacyType(data.cover?.path),
+                        width = data.cover?.width,
+                        height = data.cover?.height,
+                    ),
+                    thumbnail = CompatImage(
+                        type = pathToLegacyType(data.thumbnail?.path),
+                        width = data.thumbnail?.width,
+                        height = data.thumbnail?.height,
+                    ),
+                ),
+                scanlator = data.scanlator.nullIfBlank(),
+                uploadDate = data.toSChapter().date_upload / 1000,
+                tags = data.tags,
+                numPages = data.numPages.takeIf { it > 0 } ?: data.pages.size,
+                numFavorites = data.numFavorites,
+            )
+            val compatJson = json.encodeToString(compatPayload)
+            val escapedBody = compatJson
+                .replace("\\", "\\u005c")
+                .replace("\"", "\\u0022")
+                .replace("\n", "\\u000a")
+                .replace("\r", "\\u000d")
+                .replace("\t", "\\u0009")
+            val legacyBody = """window._gallery = JSON.parse("$escapedBody");"""
+            apiResponse.newBuilder()
+                .request(cleanRequest)
+                .body(legacyBody.toResponseBody(apiResponse.body.contentType()))
+                .build()
+        } catch (e: Exception) {
+            chain.proceed(cleanRequest)
+        }
+    }
+
     // Cdns
 
     val nhConfig: NHConfig by lazy {
@@ -136,7 +200,74 @@ open class NHentai(
     }
 
     private val shortenTitleRegex = Regex("""(\[[^]]*]|[({][^)}]*[)}])""")
+    private val galleryJsonRegex = Regex(""".parse\("(.*)"\);""")
+    private val unicodeEscapeRegex = Regex("""\\u([0-9a-fA-F]{4})""")
     private fun String.shortenTitle() = this.replace(shortenTitleRegex, "").trim()
+    private fun String?.nullIfBlank() = this?.trim()?.takeIf { it.isNotEmpty() }
+    private fun fallbackTitle(id: Int) = "Gallery #$id"
+    private fun String.decodeHtmlGalleryJson(): String {
+        val galleryJson = galleryJsonRegex.find(this)?.groupValues?.getOrNull(1)
+            ?: throw IOException("Unable to locate embedded gallery JSON")
+        return galleryJson.replace(unicodeEscapeRegex) {
+            it.groupValues[1].toInt(radix = 16).toChar().toString()
+        }
+    }
+    private fun pathToLegacyType(path: String?): String? = when (path?.substringAfterLast('.', "")) {
+        "webp" -> "w"
+        "png" -> "p"
+        "jpg", "jpeg" -> "j"
+        "gif" -> "g"
+        else -> null
+    }
+    private fun legacyThumbUrl(mediaId: String?, image: Image?, fileName: String): String? {
+        val extension = when (image?.type) {
+            "w" -> "webp"
+            "p" -> "png"
+            "j" -> "jpg"
+            "g" -> "gif"
+            else -> null
+        }
+        return if (mediaId != null && extension != null) {
+            "$thumbServer/galleries/$mediaId/$fileName.$extension"
+        } else {
+            null
+        }
+    }
+    private data class ParsedHentai(
+        val id: Int,
+        val title: Title,
+        val tags: List<Tag>,
+        val numPages: Int,
+        val numFavorites: Long,
+        val thumbnailPath: String? = null,
+        val coverPath: String? = null,
+    )
+    private fun parseGalleryBody(body: String): ParsedHentai {
+        val trimmed = body.trimStart()
+        return if (trimmed.startsWith("{")) {
+            val data = trimmed.parseAs<Hentai>(json)
+            ParsedHentai(
+                id = data.id,
+                title = data.title,
+                tags = data.tags,
+                numPages = data.numPages.takeIf { it > 0 } ?: data.pages.size,
+                numFavorites = data.numFavorites,
+                thumbnailPath = data.thumbnail?.path,
+                coverPath = data.cover?.path,
+            )
+        } else {
+            val data = body.decodeHtmlGalleryJson().parseAs<LegacyHentai>(json)
+            ParsedHentai(
+                id = data.id,
+                title = data.title,
+                tags = data.tags,
+                numPages = data.images.pages.size,
+                numFavorites = data.numFavorites,
+                thumbnailPath = legacyThumbUrl(data.mediaId, data.images.thumbnail, "thumb"),
+                coverPath = legacyThumbUrl(data.mediaId, data.images.cover, "cover"),
+            )
+        }
+    }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         ListPreference(screen.context).apply {
@@ -278,11 +409,16 @@ open class NHentai(
     }
 
     fun parseSearchData(data: GalleryItem): SManga = SManga.create().apply {
+        val englishTitle = data.englishTitle.nullIfBlank()
+        val japaneseTitle = data.japaneseTitle.nullIfBlank()
+        val fullTitle = englishTitle ?: japaneseTitle ?: fallbackTitle(data.id)
+        val shortTitle = englishTitle?.shortenTitle()
+            ?: japaneseTitle?.shortenTitle()
+            ?: fullTitle
+
         url = "/g/${data.id}/"
-        title = (data.englishTitle ?: data.japaneseTitle)!!.let {
-            if (displayFullTitle) it else it.shortenTitle()
-        }
-        thumbnail_url = "$thumbServer/${data.thumbnail}"
+        title = if (displayFullTitle) fullTitle else shortTitle
+        thumbnail_url = data.thumbnail?.let { "$thumbServer/$it" }
         status = SManga.COMPLETED
         update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
     }
@@ -291,31 +427,69 @@ open class NHentai(
 
     override fun getMangaUrl(manga: SManga) = "$baseUrl${manga.url}"
 
-    override fun mangaDetailsRequest(manga: SManga): Request = searchMangaByIdRequest(manga.url.removeSurrounding("/g/", "/"))
+    override fun mangaDetailsRequest(manga: SManga): Request {
+        val id = manga.url.removeSurrounding("/g/", "/")
+        val requestUrl = "$apiUrl/galleries/$id"
+        return GET(
+            requestUrl,
+            headersBuilder()
+                .add(DETAILS_COMPAT_HEADER, "1")
+                .build(),
+        )
+    }
 
     override fun mangaDetailsParse(response: Response): SManga {
-        val data = response.parseAs<Hentai>(json)
+        val data = response.use { parseGalleryBody(it.body.string()) }
+        val englishTitle = data.title.english.nullIfBlank()
+        val japaneseTitle = data.title.japanese.nullIfBlank()
+        val prettyTitle = data.title.pretty.nullIfBlank()
+        val fullTitle = englishTitle ?: japaneseTitle ?: prettyTitle ?: fallbackTitle(data.id)
+        val shortTitle = prettyTitle
+            ?: englishTitle?.shortenTitle()
+            ?: japaneseTitle?.shortenTitle()
+            ?: fullTitle
+        val artists = getArtists(
+            Hentai(
+                id = data.id,
+                tags = data.tags,
+                title = data.title,
+            ),
+        )
+        val groups = getGroups(
+            Hentai(
+                id = data.id,
+                tags = data.tags,
+                title = data.title,
+            ),
+        )
+        val tagData = Hentai(
+            id = data.id,
+            tags = data.tags,
+            title = data.title,
+        )
+        val thumbnailPath = data.thumbnailPath ?: data.coverPath
 
         return SManga.create().apply {
             url = "/g/${data.id}/"
-            title = if (displayFullTitle) {
-                data.title.english ?: data.title.japanese ?: data.title.pretty!!
-            } else {
-                data.title.pretty ?: (data.title.english ?: data.title.japanese)!!.shortenTitle()
+            title = if (displayFullTitle) fullTitle else shortTitle
+            thumbnail_url = thumbnailPath?.let {
+                if (it.startsWith("http")) it else "$thumbServer/$it"
             }
-            thumbnail_url = "$thumbServer/${data.thumbnail.path}"
             status = SManga.COMPLETED
-            artist = getArtists(data)
-            author = getGroups(data) ?: getArtists(data)
-            // Some people want these additional details in description
-            description = "Full English and Japanese titles:\n"
-                .plus("${data.title.english ?: data.title.japanese ?: data.title.pretty ?: ""}\n")
-                .plus(data.title.japanese ?: "")
-                .plus("\n\n")
-                .plus("Pages: ${data.numPages}\n")
-                .plus("Favorited by: ${data.numFavorites}\n")
-                .plus(getTagDescription(data))
-            genre = getTags(data)
+            artist = artists
+            author = groups ?: artists
+            description = buildString {
+                append("Full English and Japanese titles:\n")
+                appendLine(fullTitle)
+                japaneseTitle
+                    ?.takeUnless { it == fullTitle }
+                    ?.let(::appendLine)
+                appendLine()
+                append("Pages: ${data.numPages}\n")
+                append("Favorited by: ${data.numFavorites}\n")
+                append(getTagDescription(tagData))
+            }
+            genre = getTags(tagData)
             update_strategy = UpdateStrategy.ONLY_FETCH_ONCE
             initialized = true
         }
@@ -323,7 +497,7 @@ open class NHentai(
 
     // Chapter List
 
-    override fun chapterListRequest(manga: SManga): Request = mangaDetailsRequest(manga)
+    override fun chapterListRequest(manga: SManga): Request = searchMangaByIdRequest(manga.url.removeSurrounding("/g/", "/"))
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val data = response.parseAs<Hentai>(json)
@@ -339,8 +513,8 @@ open class NHentai(
 
     override fun pageListParse(response: Response): List<Page> {
         val data = response.parseAs<Hentai>(json)
-        return data.pages.mapIndexed { i, page ->
-            Page(i, imageUrl = "$imageServer/${page.path}")
+        return data.pages.mapIndexedNotNull { i, page ->
+            page.path?.let { Page(i, imageUrl = "$imageServer/$it") }
         }
     }
 
@@ -396,6 +570,7 @@ open class NHentai(
     companion object {
         const val API_KEY = "api_key"
         const val PREFIX_ID_SEARCH = "id:"
+        private const val DETAILS_COMPAT_HEADER = "X-NHentai-Compat-Details"
         private const val TITLE_PREF = "Display manga title as:"
 
         private val SORT_OPTIONS = arrayOf(


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension

## Summary by Sourcery

Fix NHentai gallery details parsing to support both the new API response format and legacy embedded JSON while improving robustness of title, thumbnail, and page handling.

New Features:
- Add a compatibility interceptor that converts NHentai API gallery responses into the legacy embedded JSON format expected by existing parsing logic.
- Support parsing NHentai gallery details from either direct API JSON or legacy HTML pages containing escaped gallery JSON.

Bug Fixes:
- Prevent crashes and broken thumbnails when NHentai responses omit thumbnails or image paths.
- Fix NHentai manga details parsing so titles, tags, and metadata load correctly with the updated API and HTML formats.
- Avoid null or empty artist fields by returning null when no artist tags are present instead of an empty string.

Enhancements:
- Improve title selection and shortening logic for NHentai search and details to better handle missing or blank English/Japanese titles and provide sensible fallbacks.
- Make NHentai DTOs and image fields more tolerant of missing data by adding defaults and nullable properties.
- Refine page list construction to skip entries without valid image paths instead of creating invalid pages.

Build:
- Bump the NHentai extension version code to 58.