### PR TITLE
nHentai: Fix proguard

### DIFF
--- a/src/all/nhentai/build.gradle
+++ b/src/all/nhentai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NHentai'
     extClass = '.NHFactory'
-    extVersionCode = 59
+    extVersionCode = 60
     isNsfw = true
 }
 

--- a/src/all/nhentai/proguard-rules.pro
+++ b/src/all/nhentai/proguard-rules.pro
@@ -1,2 +1,2 @@
 # Keep class names for reflection (qualifiedName)
--keepnames class * extends eu.kanade.tachiyomi.extension.all.nhentai.NHentai
+-keepnames class eu.kanade.tachiyomi.extension.all.nhentai.NHentai


### PR DESCRIPTION
## Summary by Sourcery

Tighten the NHentai extension ProGuard rule to only keep the intended class and bump the extension version code.

Bug Fixes:
- Correct ProGuard keep rule for the NHentai extension to target only the specific NHentai class.

Build:
- Increment the NHentai extension version code to reflect the ProGuard configuration fix.