### PR TITLE
KeiSource

### DIFF
--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -1,29 +1,15 @@
 import gzip
 import html
 import json
-import os
 import re
-import subprocess
 import sys
-from functools import cache
 from pathlib import Path
-from zipfile import ZipFile
 
 from google.protobuf import json_format
 
 import index_pb2
 
-APPLICATION_ICON_320_REGEX = re.compile(
-    r"^application-icon-320:'([^']+)'", re.MULTILINE
-)
 LANGUAGE_REGEX = re.compile(r"tachiyomi-([^.]+)")
-
-
-@cache
-def aapt() -> Path:
-    *_, build_tools = (Path(os.environ["ANDROID_HOME"]) / "build-tools").iterdir()
-    return build_tools / "aapt"
-
 
 # Artifacts downloaded from the build jobs: one APK per extension plus the source metadata JSON
 # emitted by each assembleRelease.
@@ -91,17 +77,6 @@ for info_file in ARTIFACTS_DIR.glob("**/keiyoushi-source-info.json"):
             f"{package_name}: no release jar found under {info_file.parent}"
         )
     (REPO_JAR_DIR / jar.name).write_bytes(jar.read_bytes())
-
-    badging = subprocess.check_output(
-        [aapt(), "dump", "--include-meta-data", "badging", apk]
-    ).decode()
-    application_icon = APPLICATION_ICON_320_REGEX.search(badging).group(1)
-    with (
-        ZipFile(apk) as z,
-        z.open(application_icon) as i,
-        (REPO_ICON_DIR / f"{package_name}.png").open("wb") as f,
-    ):
-        f.write(i.read())
 
     new_extensions.append(
         index_pb2.Extension(

--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -9,8 +9,6 @@ from google.protobuf import json_format
 
 import index_pb2
 
-LANGUAGE_REGEX = re.compile(r"tachiyomi-([^.]+)")
-
 # Artifacts downloaded from the build jobs: one APK per extension plus the source metadata JSON
 # emitted by each assembleRelease.
 ARTIFACTS_DIR = Path.home() / "apk-artifacts"
@@ -137,46 +135,6 @@ with REPO_DIR.joinpath("index.json").open("w", encoding="utf-8") as f:
 
 with REPO_DIR.joinpath("index.pb").open("wb") as f:
     f.write(gzip.compress(index.SerializeToString()))
-
-
-def get_legacy_lang(ext) -> str:
-    apk_filename = ext.resources.apkUrl.split("/")[-1]
-    lang = LANGUAGE_REGEX.search(apk_filename).group(1)
-    if len(ext.sources) == 1:
-        source_language = ext.sources[0].language
-        if (
-            source_language != lang
-            and source_language not in {"all", "other"}
-            and lang not in {"all", "other"}
-        ):
-            lang = source_language
-    return lang
-
-
-legacy_json_index = [
-    {
-        "name": f"Tachiyomi: {ext.name}",
-        "pkg": ext.packageName,
-        "apk": ext.resources.apkUrl.split("/")[-1],
-        "lang": get_legacy_lang(ext),
-        "code": ext.versionCode,
-        "version": ext.versionName,
-        "nsfw": 1 if ext.contentWarning > 2 else 0,
-        "sources": [
-            {
-                "name": source.name,
-                "lang": source.language,
-                "id": str(source.id),
-                "baseUrl": source.homeUrl,
-            }
-            for source in ext.sources
-        ],
-    }
-    for ext in all_extensions
-]
-
-with REPO_DIR.joinpath("index.min.json").open("w", encoding="utf-8") as f:
-    json.dump(legacy_json_index, f, ensure_ascii=False, separators=(",", ":"))
 
 with REPO_DIR.joinpath("index.html").open("w", encoding="utf-8") as f:
     f.write(

--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -1,7 +1,6 @@
 import gzip
 import html
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -66,14 +65,13 @@ for info_file in ARTIFACTS_DIR.glob("**/keiyoushi-source-info.json"):
             f"{package_name}: no release apk found under {info_file.parent}"
         )
 
-    apk_name = apk.name.replace("-release.apk", ".apk")
-    (REPO_APK_DIR / apk_name).write_bytes(apk.read_bytes())
-
     jar = next((info_file.parent / "outputs/jar/release").glob("*.jar"), None)
     if jar is None:
         raise FileNotFoundError(
             f"{package_name}: no release jar found under {info_file.parent}"
         )
+
+    (REPO_APK_DIR / apk.name).write_bytes(apk.read_bytes())
     (REPO_JAR_DIR / jar.name).write_bytes(jar.read_bytes())
 
     new_extensions.append(
@@ -81,7 +79,7 @@ for info_file in ARTIFACTS_DIR.glob("**/keiyoushi-source-info.json"):
             name=info["name"],
             packageName=package_name,
             resources=index_pb2.Resources(
-                apkUrl=f"{APK_BASE_URL}/{apk_name}",
+                apkUrl=f"{APK_BASE_URL}/{apk.name}",
                 jarUrl=f"{JAR_BASE_URL}/{jar.name}",
                 iconUrl=get_icon_url(info["module"], info.get("theme")),
             ),
@@ -134,7 +132,7 @@ with REPO_DIR.joinpath("index.json").open("w", encoding="utf-8") as f:
     )
 
 with REPO_DIR.joinpath("index.pb").open("wb") as f:
-    f.write(gzip.compress(index.SerializeToString()))
+    f.write(gzip.compress(index.SerializeToString(deterministic=True)))
 
 with REPO_DIR.joinpath("index.html").open("w", encoding="utf-8") as f:
     f.write(

--- a/.github/scripts/publish-repo.py
+++ b/.github/scripts/publish-repo.py
@@ -33,14 +33,12 @@ ARTIFACTS_DIR = Path.home() / "apk-artifacts"
 REPO_DIR = Path.cwd()
 REPO_APK_DIR = REPO_DIR / "apk"
 REPO_JAR_DIR = REPO_DIR / "jar"
-REPO_ICON_DIR = REPO_DIR / "icon"
 REPO_APK_DIR.mkdir(parents=True, exist_ok=True)
 REPO_JAR_DIR.mkdir(parents=True, exist_ok=True)
-REPO_ICON_DIR.mkdir(parents=True, exist_ok=True)
 
 APK_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/cursed-manga-repo@repo/apk"
 JAR_BASE_URL = "https://raw.githubusercontent.com/yuzono/cursed-manga-repo/repo/jar"
-ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/cursed-manga-repo@repo/icon"
+ICON_BASE_URL = "https://cdn.jsdelivr.net/gh/yuzono/cursed-manga-extensions@master"
 
 to_delete: list[str] = json.loads(sys.argv[1])
 
@@ -52,14 +50,27 @@ for module in to_delete:
     for file in REPO_JAR_DIR.glob(f"tachiyomi-{module}-v*.*.*.jar"):
         print(f"removing {file.name}")
         file.unlink(missing_ok=True)
-    for file in REPO_ICON_DIR.glob(f"eu.kanade.tachiyomi.extension.{module}.png"):
-        print(f"removing {file.name}")
-        file.unlink(missing_ok=True)
 
 # Build index entries for the freshly built apks. Each extension's metadata comes from the
 # source-info JSON emitted by its assembleRelease task (see GenerateSourceInfoTask); its APK is a
 # sibling in the same build dir. aapt reads the icon out of the APK
 new_extensions: list[index_pb2.Extension] = []
+
+SOURCE_DIR = Path(__file__).resolve().parents[2]
+ICON_FILE = "res/mipmap-xhdpi/ic_launcher.png"
+
+
+def get_icon_url(module: str, theme: str | None) -> str:
+    module_icon = f"src/{module.replace('.', '/')}/{ICON_FILE}"
+    if (SOURCE_DIR / module_icon).exists():
+        return f"{ICON_BASE_URL}/{module_icon}"
+
+    if theme:
+        theme_icon = f"lib-multisrc/{theme}/{ICON_FILE}"
+        if (SOURCE_DIR / theme_icon).exists():
+            return f"{ICON_BASE_URL}/{theme_icon}"
+
+    return f"{ICON_BASE_URL}/core/src/main/{ICON_FILE}"
 
 for info_file in ARTIFACTS_DIR.glob("**/keiyoushi-source-info.json"):
     with info_file.open(encoding="utf-8") as f:
@@ -99,7 +110,7 @@ for info_file in ARTIFACTS_DIR.glob("**/keiyoushi-source-info.json"):
             resources=index_pb2.Resources(
                 apkUrl=f"{APK_BASE_URL}/{apk_name}",
                 jarUrl=f"{JAR_BASE_URL}/{jar.name}",
-                iconUrl=f"{ICON_BASE_URL}/{package_name}.png",
+                iconUrl=get_icon_url(info["module"], info.get("theme")),
             ),
             extensionLib=info["extensionLib"],
             versionCode=info["versionCode"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Agent instructions
+
+Before writing or modifying any extension, multisrc theme, or lib code in this repository, **read
+[CONTRIBUTING.md](CONTRIBUTING.md) in full**. It is the source of truth for conventions here and is
+updated frequently - do not rely on prior knowledge of this codebase or of Tachiyomi/Mihon
+extensions in general, since common patterns have changed.
+
+A few points that are easy to get wrong from stale training data:
+
+- **New sources must extend `KeiSource`** (`libVersion = "1.6"`), never `HttpSource` directly.
+  `HttpSource`/`libVersion = "1.4"` only exists in extensions/themes not yet migrated - see
+  [KeiSource](CONTRIBUTING.md#keisource).
+  - **Metadata is injected via KSP:** Do NOT manually declare or `override val name`, `lang`, `id`, or `baseUrl` in your `@Source` class. These are defined using `source {}` blocks in `build.gradle.kts` and injected automatically.
+- **`SourceFactory` is obsolete:** Do NOT implement `SourceFactory` to create multiple sources. Instead, add multiple `source {}` blocks in the extension's `build.gradle.kts`.
+- **Generated Preferences:** Do NOT write manual `SharedPreferences` logic for base URL mirrors or custom user URLs. Use `baseUrl { mirrors(...) }` or `baseUrl { custom(...) }` inside the `source {}` block in `build.gradle.kts`.
+- **Deeplinks are DSL-driven:** Declare URL intent filters using the `deeplink {}` block in `build.gradle.kts`. Do NOT modify `AndroidManifest.xml` or write manual intent filtering logic.
+- **DTOs must be regular classes:** Do NOT use `data class` for `@Serializable` JSON/Protobuf DTOs (it bloats bytecode). Use a regular `class`, make fields `private` where possible, and only use `@SerialName` when the JSON key differs from the camelCase property name.
+- **No local JSON/Proto instances:** Do NOT create `private val json: Json by injectLazy()`. Use the shared `keiyoushi.utils` helpers like `response.parseAs<T>()`, `toJsonRequestBody()`, or `parseAsProto<T>()`.
+- Use `ext-bootstrap.py` to scaffold new extensions rather than hand-writing the module structure -
+  see [Using ext-bootstrap.py](CONTRIBUTING.md#using-ext-bootstrappy).
+- Prefer the helpers documented under
+  [keiyoushi.utils (core utilities)](CONTRIBUTING.md#keiyoushiutils-core-utilities) (JSON parsing,
+  HTTP requests, date parsing, GraphQL, WebView execution, etc.) over hand-rolled equivalents.
+- Check [Available libs](CONTRIBUTING.md#available-libs) before implementing something from scratch
+  that a `lib/` module may already solve.
+- Don't add excessive or obvious comments explaining what code does; only comment on non-obvious
+  *why* (a workaround, a subtle invariant, a site-specific quirk).
+- Don't over-engineer. No speculative abstractions, config options, or generalization beyond what
+  was asked, and no "just in case" error handling, fallbacks, or validation for scenarios that
+  can't actually happen.
+
+If anything in this file conflicts with `CONTRIBUTING.md`, `CONTRIBUTING.md` wins.
+
+## Scope
+
+For a typical "add/fix a source" task, only change files under `src/` (individual extensions),
+`lib-multisrc/` (multisrc themes), or - in rare cases - `lib/`. Leave `core/`, `compiler/`,
+`common/`, `gradle/`, and other build-logic/infrastructure files alone unless you were explicitly
+asked to change them - that's a different, higher-risk category of work.
+
+## Before committing / opening a PR
+
+Format the module(s) you touched, not the whole repo - a full-repo Spotless run is slow on
+this monorepo. Use the module's Gradle path, e.g. for a single extension:
+
+```bash
+./gradlew :src:en:mysource:spotlessApply
+```
+
+or for a theme: `./gradlew :lib-multisrc:madara:spotlessApply`.
+
+Spotless also runs as part of `preBuild`, so a full build would catch violations too - running it
+scoped like this first is just faster.
+
+## Opening a pull request
+
+If you are an AI agent asked to open a pull request, disclose that at the end of the PR
+description: what you were asked to do, and that the PR was opened by an AI agent. Start that note
+with a 🤖 emoji. This is in addition to, not a substitute for, the "This PR is AI-assisted..."
+checklist item in the [Pull Request checklist](CONTRIBUTING.md#pull-request-checklist) - that box
+still needs to be checked by the human who reviewed your changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ or fix them directly by submitting a Pull Request.
   - [Prerequisites](#prerequisites)
     - [Tools](#tools)
     - [Cloning the repository](#cloning-the-repository)
+    - [Non-cone mode (Deprecated/Discouraged)](#non-cone-mode-deprecateddiscouraged)
   - [Getting help](#getting-help)
   - [Writing an extension](#writing-an-extension)
     - [Setting up a new Gradle module](#setting-up-a-new-gradle-module)
@@ -38,7 +39,9 @@ or fix them directly by submitting a Pull Request.
         - [JSON serialization - `toJsonString` / `toJsonRequestBody`](#json-serialization---tojsonstring--tojsonrequestbody)
         - [JSON models (DTOs) and serialization](#json-models-dtos-and-serialization)
         - [Protobuf parsing and serialization - `parseAsProto` / `toRequestBodyProto`](#protobuf-parsing-and-serialization---parseasproto--torequestbodyproto)
-        - [Date parsing - `tryParse`](#date-parsing---tryparse)
+        - [Date parsing - `Instant.parseOrNull` / `java.time`](#date-parsing---instantparseornull--javatime)
+        - [HTTP requests - `OkHttpClient.get` / `post` / `put` / `head`](#http-requests---okhttpclientget--post--put--head)
+        - [WebView execution - `runWebView` / `getLocalStorage`](#webview-execution---runwebview--getlocalstorage)
         - [Filter helpers - `firstInstance` / `firstInstanceOrNull`](#filter-helpers---firstinstance--firstinstanceornull)
         - [SharedPreferences - `getPreferences` / `getPreferencesLazy`](#sharedpreferences---getpreferences--getpreferenceslazy)
         - [Next.js data extraction - `extractNextJs` / `extractNextJsRsc`](#nextjs-data-extraction---extractnextjs--extractnextjsrsc)
@@ -49,6 +52,7 @@ or fix them directly by submitting a Pull Request.
         - [ZIP streaming - `readZipDirectory` / `readZipEntry`](#zip-streaming---readzipdirectory--readzipentry)
       - [Additional dependencies](#additional-dependencies)
     - [Extension main class](#extension-main-class)
+      - [KeiSource](#keisource)
       - [Main class key variables](#main-class-key-variables)
     - [HTML and Image Processing](#html-and-image-processing)
     - [OkHttp and Network](#okhttp-and-network)
@@ -246,7 +250,9 @@ $ python ext-bootstrap.py -n "My Source" -l en -u https://mysource.com
 ```
 
 This creates `src/<lang>/<mysourcename>/build.gradle.kts` along with the extension's package
-directory and a starter source class implementing `HttpSource`.
+directory and a starter source class. New (non-multisrc) sources are scaffolded extending
+`KeiSource` with `libVersion = "1.6"`; sources based on an existing multisrc theme (`-m`) inherit
+whatever base class and `libVersion` that theme uses.
 
 Available options:
 
@@ -329,7 +335,7 @@ keiyoushi {
     name = "Example" // Replace with your actual source name
     versionCode = 1
     contentWarning = ContentWarning.NSFW // Options: ContentWarning.SAFE, ContentWarning.MIXED, ContentWarning.NSFW
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         name = "Example" // Optional, defaults to the top-level name
@@ -341,18 +347,18 @@ keiyoushi {
 
 At least one `source {}` block is required for every extension.
 
-| Field            | Description                                                                                                                                                                                                                                                                                                              |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`           | The name of the extension. Should be romanized if site name is not in English.                                                                                                                                                                                                                                           |
-| `versionCode`    | The extension version code. This must be a positive integer and incremented with any change to the code. Do not bump for changes that do not affect users, such as changing a private function to a public function.                                                                                                     |
-| `contentWarning` | Content safety classification. Must be set explicitly to one of `ContentWarning.SAFE`, `ContentWarning.MIXED`, or `ContentWarning.NSFW`.                                                                                                                                                                                 |
-| `libVersion`     | The extension library version. Always set to `"1.4"`.                                                                                                                                                                                                                                                                    |
-| `theme`          | Name of a multi-source theme from `lib-multisrc/` to inherit from (e.g. `"madara"`). When set, the extension's version code is `theme.baseVersionCode + versionCode`.                                                                                                                                                    |
-| `source {}`      | Declares one source (or multiple, for multi-language or multi-mirror extensions) using KSP code generation. This block is mandatory. See [Source declaration](#source-declaration).                                                                                                                                      |
-| `deeplink {}`    | Declares a URL deeplink intent filter. See [URL intent filter](#url-intent-filter).                                                                                                                                                                                                                                      |
+| Field            | Description                                                                                                                                                                                                                               |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`           | The name of the extension. Should be romanized if site name is not in English.                                                                                                                                                            |
+| `versionCode`    | The extension version code. This must be a positive integer and incremented with any change to the code. Do not bump for changes that do not affect users, such as changing a private function to a public function.                      |
+| `contentWarning` | Content safety classification. Must be set explicitly to one of `ContentWarning.SAFE`, `ContentWarning.MIXED`, or `ContentWarning.NSFW`.                                                                                                  |
+| `libVersion`     | The extension library version. All new extensions must set this to `"1.6"` and implement `KeiSource` (see [Extension main class](#extension-main-class)). `"1.4"` is legacy and only found in extensions that have not yet been migrated. |
+| `theme`          | Name of a multi-source theme from `lib-multisrc/` to inherit from (e.g. `"madara"`). When set, the extension's version code is `theme.baseVersionCode + versionCode`.                                                                     |
+| `source {}`      | Declares one source (or multiple, for multi-language or multi-mirror extensions) using KSP code generation. This block is mandatory. See [Source declaration](#source-declaration).                                                       |
+| `deeplink {}`    | Declares a URL deeplink intent filter. See [URL intent filter](#url-intent-filter).                                                                                                                                                       |
 
 The extension's version name is generated automatically by concatenating `libVersion` and the calculated version code.
-With the example used above, the version would be `1.4.1`.
+With the example used above, the version would be `1.6.1`.
 
 ### Source declaration
 
@@ -364,13 +370,16 @@ Add `@Source` to your main class and remove any manual declarations of `name`, `
 
 ```kotlin
 import keiyoushi.annotation.Source
+import keiyoushi.source.KeiSource
 
 @Source
-abstract class MySource : HttpSource() {
+abstract class MySource : KeiSource() {
     // name, lang, id, and baseUrl are injected automatically - do not declare them here.
     // All other overrides go here as normal.
 }
 ```
+
+New sources must extend `KeiSource` (with `libVersion = "1.6"`), never `HttpSource` directly - see [Extension main class](#extension-main-class) for details.
 
 #### Declare sources in build.gradle.kts
 
@@ -381,7 +390,7 @@ keiyoushi {
     name = "My Source"
     versionCode = 1
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         lang = "en"
@@ -466,7 +475,7 @@ keiyoushi {
     name = "Example"
     versionCode = 1
     contentWarning = ContentWarning.SAFE
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     source {
         name = "Example EN"
@@ -634,7 +643,7 @@ val jsonString = myRequestDto.toJsonString()
 
 When defining `@Serializable` classes for JSON parsing, **do not** use `data class` unless you actually need data class features (like `copy()` or destructuring). Use a regular `class` instead to reduce the generated bytecode size.
 
-Always use camelCase for Kotlin properties. Only use `@SerialName` when the JSON key does not match the property name (e.g., mapping a snake_case JSON key like `cover_img` to `coverImg`, or an invalid Kotlin identifier like `_count` to `count`). If the JSON key already matches the property name exactly, `@SerialName` is redundant and should be omitted. It is also recommended to make fields `private` if they are only used internally (for instance, when mapping directly to `SManga` or `SChapter` within the DTO).
+Always use camelCase for Kotlin properties, except when mapping to external model properties that use snake_case (e.g., `thumbnail_url` in `SManga` or `date_upload` in `SChapter`). Only use `@SerialName` when the JSON key does not match the property name (e.g., mapping a snake_case JSON key like `cover_img` to `coverImg`, or an invalid Kotlin identifier like `_count` to `count`). If the JSON key already matches the property name exactly, `@SerialName` is redundant and should be omitted. It is also recommended to make fields `private` if they are only used internally (for instance, when mapping directly to `SManga` or `SChapter` within the DTO).
 
 ```kotlin
 import kotlinx.serialization.SerialName
@@ -692,41 +701,113 @@ If you only need to work with raw bytes, you can also use `.decodeProto()` and `
 
 Do not create a local `private val proto: ProtoBuf by injectLazy()` unless you specifically need a custom configuration. For standard parsing, the global instance is already available and the `parseAsProto` helpers use it automatically.
 
-##### Date parsing - `tryParse`
+##### Date parsing - `Instant.parseOrNull` / `java.time`
 
-Use `keiyoushi.utils.tryParse` on a `SimpleDateFormat` instance to safely parse a date string.
-It returns `0L` on failure or when the input is `null`, which is exactly what the app expects.
+For **ISO-8601** date strings (e.g. `2024-03-05T12:30:00Z`), prefer `kotlin.time.Instant.parseOrNull`:
 
 ```kotlin
-import keiyoushi.utils.tryParse
+import kotlin.time.Instant
 
-// Declare dateFormat at class/file level - creating SimpleDateFormat is expensive:
-private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT).apply {
-    timeZone = TimeZone.getTimeZone("UTC")
-}
-
-chapter.date_upload = dateFormat.tryParse(dateStr)
+chapter.date_upload = Instant.parseOrNull(dateStr)?.toEpochMilliseconds() ?: 0L
 ```
 
-**Do not** write manual try/catch blocks or null-guards around `SimpleDateFormat.parse()`;
-`tryParse` handles both. Also, always declare your `SimpleDateFormat` as a class-level or
-file-level `val` so it is not reconstructed for every chapter.
+It returns `null` on a malformed string instead of throwing, and needs no format pattern, locale, or
+timezone handling - `parseOrNull` only accepts strict ISO-8601 (with an explicit `Z` or offset), so
+fall back to `java.time` for anything else (e.g. `dd MMM yyyy`, or a site-local format with no
+offset).
 
-Two common mistakes to avoid:
+For those non-ISO formats, prefer `java.time` (`DateTimeFormatter` with `LocalDate`/`LocalDateTime`/
+`OffsetDateTime`) over `SimpleDateFormat`, which is discouraged for new code. Wrap the parse in
+`runCatching` so a malformed or unexpected string falls back to `0L` instead of crashing:
 
-- **Always set `Locale.ROOT`**, unless the pattern contains locale-sensitive text (such as month names), in which case use the appropriate locale.
-- **Set the timezone** if known, either if the site's region is known or because the pattern uses a literal `'Z'`.
+```kotlin
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+// Declare the formatter at class/file level - creating one is not free:
+private val dateFormat = DateTimeFormatter.ofPattern("dd MMM yyyy", Locale.ENGLISH)
+
+chapter.date_upload = runCatching {
+    LocalDate.parse(dateStr, dateFormat).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+}.getOrDefault(0L)
+```
+
+If a site mixes ISO and non-ISO shapes in the same field (rare, but happens), chain the attempts with
+`recoverCatching` instead of hand-rolling detection logic:
+
+```kotlin
+runCatching { Instant.parse(dateStr).toEpochMilliseconds() }
+    .recoverCatching { LocalDate.parse(dateStr, dateFormat).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli() }
+    .getOrDefault(0L)
+```
+
+Only reach for `SimpleDateFormat` + `keiyoushi.utils.tryParse` if `java.time` genuinely can't express
+the pattern you need; it is otherwise discouraged in new code.
+
+Two common mistakes to avoid, regardless of which API you use:
+
+- **Always set `Locale.ROOT`** (or `Locale.ENGLISH` for `java.time`, which requires a non-root locale for some symbol sets), unless the pattern contains locale-sensitive text (such as month names), in which case use the appropriate locale.
+- **Set the timezone/offset** if known, either because the site's region is known or because the pattern uses a literal `'Z'`.
 
   ```kotlin
-  // Wrong: 'Z' is treated as a literal character, timezone defaults to device local time
-  SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT)
-  // Correct:
-  SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT).apply {
-      timeZone = TimeZone.getTimeZone("UTC")
-  }
-  // Also correct (Z without quotes parses the timezone offset from the string):
-  SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ROOT)
+  // Wrong: 'Z' is treated as a literal character, no offset is applied
+  DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  // Correct, if you must parse this shape by hand at all - prefer Instant.parseOrNull instead:
+  LocalDateTime.parse(dateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")).toInstant(ZoneOffset.UTC)
   ```
+
+##### HTTP requests - `OkHttpClient.get` / `post` / `put` / `head`
+
+Always make requests with the `keiyoushi.network` suspend extensions on `OkHttpClient` - `get`,
+`post`, `put`, and `head`. Use them for every request inside your `KeiSource` suspend functions
+(`getPopularManga`, `getSearchMangaList`, `fetchMangaUpdate`, `getPageList`, etc.) instead of
+building a `Request` and calling `client.newCall(request).execute()`/`.await()` by hand.
+
+```kotlin
+import keiyoushi.network.get
+import keiyoushi.network.post
+
+// GET with an explicit Headers object:
+val response = client.get(url, headers)
+
+// Inside a source, headers can be omitted - your own `headers` are used automatically:
+val response = client.get(url)
+
+// POST with a request body:
+val response = client.post(url, headers, body)
+```
+
+- `url` may be a `String` or an `HttpUrl`.
+- `ensureSuccess` (default `true`) throws if the response isn't 2xx; pass `ensureSuccess = false` to inspect non-2xx responses yourself.
+- `get`/`head` also take a `cacheControl` (defaults to a 10-minute max-age).
+- Always wrap the returned `Response` in `response.use { ... }` or consume it with `parseAs`/`asJsoup`, which close it for you.
+
+##### WebView execution - `runWebView` / `getLocalStorage`
+
+When a source needs a real browser environment (e.g. to solve a JS challenge, run obfuscated
+client-side code, or read a token out of `localStorage`), use `keiyoushi.utils.runWebView` instead
+of instantiating a `WebView` manually.
+
+```kotlin
+import keiyoushi.utils.runWebView
+
+val html = runWebView<String> {
+    onPageFinished { url ->
+        evaluateJs("document.documentElement.outerHTML") { html ->
+            resolve(html)
+        }
+    }
+    loadUrl(targetUrl)
+}
+```
+
+- `runWebView(session, timeout, configure)` suspends until `resolve`/`reject` is called inside `configure`, or `timeout` (default 30s) elapses; it always runs on the main thread internally.
+- The `WebViewScope` DSL exposes: `javaScriptEnabled`/`domStorageEnabled`/`blockImages`/`useWideViewPort`/`loadWithOverviewMode`/`userAgent` settings, `useOkHttpNetwork` (routes WebView requests through the app's own OkHttp client), `onPageStarted`/`onPageFinished`/`onReceivedError` hooks, `interceptRequest` to inspect/replace/block resource loads, `jsBridge(name, handler)` to expose a `window.<name>.post(message)` callback from the page, `loadUrl`/`loadData`, `evaluateJs`, and `poll(interval)` to repeat a check until resolved.
+- Pass a shared `WebViewSession` if the same source needs to reuse one WebView instance across multiple calls (e.g. to keep cookies/state) instead of spinning up a new one each time; it is torn down automatically after an idle timeout.
+- For the common case of just reading a `localStorage` value after loading a page, use the ready-made `getLocalStorage(url, key)` helper instead of writing your own `runWebView` call.
+- `runWebViewBlocking(call, ...)` exists for non-suspend call sites (e.g. inside an OkHttp interceptor where you must pass the interceptor's chain.call()) - only use it there, never from a suspend function.
 
 ##### Filter helpers - `firstInstance` / `firstInstanceOrNull`
 
@@ -858,9 +939,8 @@ To automatically throw `GraphQLException` for every request on a client rather t
 ```kotlin
 import keiyoushi.utils.GraphQLErrorInterceptor
 
-override val client = network.client.newBuilder()
-    .addInterceptor(GraphQLErrorInterceptor())
-    .build()
+override fun OkHttpClient.Builder.configureClient() =
+    addInterceptor(GraphQLErrorInterceptor())
 ```
 
 ##### JsonElement accessor helpers
@@ -892,24 +972,15 @@ Prefer these over writing `element.jsonObject["key"]?.jsonPrimitive?.content` ma
 For sources that serve manga pages as remote ZIP archives, the `keiyoushi.zip` package lets you read the central directory and individual entries using HTTP Range requests - no need to download the entire file. Import from `keiyoushi.zip`:
 
 ```kotlin
-import keiyoushi.zip.readZipDirectory
 import keiyoushi.zip.readZipEntry
-import keiyoushi.zip.range
+import keiyoushi.zip.zipDirectory
 
-// 1. Fetch the ZIP central directory (two Range requests at most).
-val directory = readZipDirectory(totalFileSizeInBytes) { byteRange ->
-    client.newCall(
-        GET(zipUrl, headers).newBuilder().range(byteRange).build()
-    ).execute().body.source().buffer()
-}
+// 1. Fetch the ZIP central directory (automatically resolves total size).
+val directory = client.zipDirectory(zipUrl, headers)
 
 // 2. Find an entry by name and read its decompressed bytes.
 val entry = directory.entries.first { it.name == "001.jpg" }
-val imageBytes = readZipEntry(entry) { byteRange ->
-    client.newCall(
-        GET(zipUrl, headers).newBuilder().range(byteRange).build()
-    ).execute().body.source().buffer()
-}.buffer().readByteArray()
+val imageBytes = client.readZipEntry(zipUrl, entry, headers).buffer().readByteArray()
 ```
 
 `readZipDirectory` resolves every entry's offset to an absolute file position and handles ZIP64 archives. `readZipEntry` fetches only the bytes for that one entry. Use this instead of downloading the full ZIP into a `ZipInputStream`, which forces the entire archive into memory.
@@ -937,16 +1008,78 @@ the main app has at the expense of app size.
 
 ### Extension main class
 
-The class annotated with `@Source` and referenced by your `source {}` block(s). This class should implement `HttpSource`.
+The class annotated with `@Source` and referenced by your `source {}` block(s). **All new
+extensions must implement `KeiSource`** (`libVersion = "1.6"`). Existing extensions/themes still
+extending `HttpSource` directly are legacy (`libVersion = "1.4"`); do not use `HttpSource` directly
+for new sources.
 
 > [!NOTE]
 > `className` is set to `ExtensionGenerated` automatically by the build system.
 
-| Class              | Description                                                                                                                           |
-|--------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `SourceFactory`    | **Obsolete.** Used to expose multiple `Source`s manually. With `source {}` blocks, this is generated automatically.                   |
-| `HttpSource`       | For online source, where requests are made using HTTP. Use this directly or extend a theme base class.                                |
-| `ParsedHttpSource` | Deprecated, use `HttpSource` instead.                                                                                                 |
+| Class              | Description                                                                                                                                                                                     |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SourceFactory`    | **Obsolete.** Used to expose multiple `Source`s manually. With `source {}` blocks, this is generated automatically.                                                                             |
+| `KeiSource`        | **The base class for all new online sources** (`libVersion = "1.6"`). A suspend-based API. Use this directly or extend a `KeiSource`-based theme base class. See [KeiSource](#keisource) below. |
+| `HttpSource`       | Legacy base class (`libVersion = "1.4"`). Only found in extensions/themes not yet migrated to `KeiSource`. Do not use for new sources.                                                          |
+| `ParsedHttpSource` | Deprecated, use `KeiSource` instead.                                                                                                                                                            |
+
+#### KeiSource
+
+`KeiSource` (package `keiyoushi.source`) is a suspend-function-based source API. Use it for every
+new source.
+
+Methods you must implement (no default - the class will not compile without them):
+
+| Method                                                                                                                               | Notes                                                                                                                                      |
+|--------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `suspend fun getPopularManga(page: Int): MangasPage`                                                                                 | Make your HTTP calls with `client` (see [HTTP requests](#http-requests---okhttpclientget--post--put--head)) directly inside this function. |
+| `suspend fun getLatestUpdates(page: Int): MangasPage`                                                                                | Only called when `supportsLatest` is `true` (defaults to `true` on `KeiSource`).                                                           |
+| `suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage`                                          | Plain-text/filter search only; URL search queries are already routed to `getMangaByUrl`/`getMangasByUrl` instead.                          |
+| `suspend fun fetchMangaUpdate(manga: SManga, chapters: List<SChapter>, fetchDetails: Boolean, fetchChapters: Boolean): SMangaUpdate` | See below - whether to honor the flags depends on whether details and chapters come from the same request.                                 |
+| `suspend fun getPageList(chapter: SChapter): List<Page>`                                                                             | Fetch and parse the page list directly here.                                                                                               |
+
+Optional overrides (each has a working default; override only when your source needs different behavior):
+
+| Method                                                             | Default                                                          | Override when...                                                                                                                                                                                        |
+|----------------------------------------------------------------------|----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `fun getHomeUrl(): String`                                            | Returns `baseUrl`.                                              | The browse screen's "Open in WebView" action should land somewhere other than `baseUrl` (e.g. the source's real site differs from the API host used as `baseUrl`).                                      |
+| `suspend fun getImageUrl(page: Page): String`                         | Not called unless a `Page.imageUrl` is empty.                   | A page's image URL can't be determined upfront in `getPageList` and must be resolved lazily once the chapter is opened - see [Chapter Pages](#chapter-pages). Make your request with `client` and return the URL directly. |
+| `fun getMangaUrl(manga: SManga): String`                              | Returns `baseUrl + manga.url`.                                  | That doesn't land on the manga's real page. Since `SManga.url` is recommended to hold just an ID/slug rather than a full relative path (see [Misc notes](#misc-notes)), the default concatenation often isn't a valid path by itself - override to build the real URL from the ID/slug (e.g. `"$baseUrl/manga/${manga.url}"`).      |
+| `fun getChapterUrl(chapter: SChapter): String`                        | Returns `baseUrl + chapter.url`.                                | Same reasoning as `getMangaUrl`, for chapters.                                                                                                                                                            |
+| `suspend fun getMangaByUrl(url: HttpUrl): SManga?`                    | Throws (unimplemented).                                         | Almost always: this backs URL search (pasting/opening a manga link for this source). Return `null` if the URL isn't recognized - leaving this unimplemented means URL search crashes for this source.  |
+| `suspend fun getMangasByUrl(url: HttpUrl, page: Int): MangasPage`     | Wraps `getMangaByUrl`'s result into a single-item `MangasPage`. | A URL can resolve to more than one manga (e.g. a listing/category page URL) - override this instead of/alongside `getMangaByUrl`.                                                                       |
+| `val supportsRelatedMangas: Boolean`                                  | `false`.                                                         | Recommended whenever the site itself surfaces related/similar manga - set to `true` and implement `fetchRelatedMangaList`. **Only works on Komikku.**                                                   |
+| `val supportRelatedMangasBySearch: Boolean`                           | `false`.                                                         | Related manga should fall back to searching the source by title when a direct related-manga list isn't available. **Only works on Komikku.**                                                           |
+| `suspend fun fetchRelatedMangaList(manga: SManga): List<SManga>`      | Returns `emptyList()`.                                           | Only called when `supportsRelatedMangas` is `true`.                                                                                                                                                      |
+| `val supportsFilterFetching: Boolean`                                 | `false`.                                                         | The source needs to fetch its filter options from the network - see filter fetching below.                                                                                                              |
+| `suspend fun fetchFilterData(): JsonElement`                          | Returns `JsonNull`.                                              | Paired with `supportsFilterFetching = true`.                                                                                                                                                              |
+| `fun getFilterList(data: JsonElement?): FilterList`                   | Returns an empty `FilterList`.                                   | The source has any filters at all, fetched or static.                                                                                                                                                    |
+| `fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder`    | No changes.                                                      | Timeouts, extra interceptors, cookie/cache/DNS config - `client` itself is `final` on `KeiSource`.                                                                                                       |
+| `fun Headers.Builder.configureHeaders(): Headers.Builder`             | No changes.                                                      | Extra default headers beyond the `Referer`/`Origin` `KeiSource` already sets - `headersBuilder()` itself is `final`.                                                                                     |
+
+**`fetchMangaUpdate`:** if manga details and the chapter list come from the same page or the same
+API response, fetch and parse it once and return both the updated `SManga` and the full chapter
+list, regardless of the `fetchDetails`/`fetchChapters` flags - there's no separate request to skip,
+so honoring the flags would just mean discarding data you already parsed. If details and chapters
+instead live behind separate pages/endpoints, only fetch what each flag actually asks for; when
+both `fetchDetails` and `fetchChapters` are `true`, prefer firing both requests concurrently (e.g.
+with `coroutineScope { async { ... } }`) instead of awaiting them sequentially.
+
+Behavior `KeiSource` gives you for free:
+
+- **No manual request/parse split.** There is no `popularMangaRequest`/`popularMangaParse`,
+  `pageListRequest`/`pageListParse`, etc. - make the request and parse the response in the same
+  suspend function.
+- **Automatic URL search:** `getSearchManga` inspects the query; if it parses as an `HttpUrl`, it
+  calls `getMangasByUrl`/`getMangaByUrl` instead of `getSearchMangaList`. You do not need to handle
+  this manually.
+- **Headers:** `headersBuilder()` already sets `Referer` and `Origin` to `baseUrl`; override
+  `Headers.Builder.configureHeaders()` instead of `headersBuilder()` to add more.
+- **Filter fetching:** if a source needs to fetch its filter options from the network, set
+  `supportsFilterFetching = true`, implement `fetchFilterData()` (returns the raw filter data as a
+  `JsonElement`, called on a background coroutine, retried up to 3 times on failure, and cached to
+  disk for 3 days), and implement `getFilterList(data: JsonElement?)` (pure, synchronous - build a
+  `FilterList` from cached data, `null` on first launch or if fetching failed/hasn't completed yet).
 
 #### Main class key variables
 
@@ -990,6 +1123,13 @@ The class annotated with `@Source` and referenced by your `source {}` block(s). 
 
 ### OkHttp and Network
 
+> [!NOTE]
+> `GET()`/`POST()` below build a `Request` object without executing it. On `KeiSource`, prefer the
+> `OkHttpClient.get`/`post`/`put`/`head` suspend helpers (see
+> [HTTP requests](#http-requests---okhttpclientget--post--put--head)), which build and execute the
+> call in one step; reach for `GET()`/`POST()` directly only if you need the `Request` itself
+> (e.g. to pass to something other than `client`).
+
 - **Always pass `headers`:** Every `GET()` and `POST()` call must include `headers` (or a custom headers object). Omitting headers will send the request without the app's default User-Agent and other expected headers.
 - **Referer header trailing slash:** When setting a `Referer` header pointing to the site root, always include a trailing slash: `.add("Referer", "$baseUrl/")`. This matches what browsers send and is required by some servers.
 - **Static URLs don't need `HttpUrl.Builder`:** Use string interpolation directly for URLs with no dynamic query parameters. Only use `HttpUrl.Builder` (or `.toHttpUrl().newBuilder()`) when query parameters need URL-encoding or the URL is built conditionally.
@@ -998,25 +1138,28 @@ The class annotated with `@Source` and referenced by your `source {}` block(s). 
   // Unnecessary builder for a static URL:
   val url = "$baseUrl/manga".toHttpUrl().newBuilder().build()
   // Prefer:
-  return GET("$baseUrl/manga", headers)
+  client.get("$baseUrl/manga")
   ```
 
 - **GraphQL Queries:** If you are sending GraphQL requests, use Kotlin's raw multi-dollar string interpolation (`$$"""..."""`) for your queries. This prevents having to escape every JSON variable `$` symbol manually. For building the request and parsing the response, prefer the `graphQLPost` and `parseGraphQLAs` helpers in `keiyoushi.utils`.
 - **Empty checks on `.text()`:** Because Jsoup's `.text()` automatically trims whitespace, you can use `.isNotEmpty()` instead of `.isNotBlank()` when checking for empty strings. The same applies to `.ownText()`. This also means you should not use `.trim()` with these functions.
-- **Use `network.client` for Cloudflare:** When overriding the client for sources, simply use `override val client = network.client.newBuilder()...`.
+- **Customize the client via `configureClient()`, not `client` directly:** On `KeiSource`, `client` is `final`; override `OkHttpClient.Builder.configureClient()` instead (see [KeiSource](#keisource)) - e.g. `override fun OkHttpClient.Builder.configureClient() = rateLimit(...)`.
 - **Never use `Thread.sleep()`:** Do not use `Thread.sleep()` for rate limiting. Use the `keiyoushi.network.rateLimit` builder extension function on your `OkHttpClient.Builder` instead.
-- **Avoid synchronous calls in `parse` methods:** Do not call `client.newCall(...).execute()` inside parsing methods like `pageListParse` or `chapterListParse`. Make the request part of the standard flow by overriding the corresponding request method (e.g., `pageListRequest`) or `fetchImageUrl`.
-- **Pass `HttpUrl` directly:** The `GET()` and `POST()` helpers accept an `HttpUrl` object. Do not call `.toString()` on a built `HttpUrl` before passing it.
+- **Never call `client.newCall(...).execute()` directly from a suspend function:** Use the suspend `OkHttpClient.get`/`post`/`put`/`head` helpers instead (see [HTTP requests](#http-requests---okhttpclientget--post--put--head)); they suspend properly instead of blocking a thread. This doesn't apply to genuinely synchronous, non-suspend callback contexts (an `OkHttp` interceptor, a WebView bridge, or the `fetch` callback passed to `readZipDirectory`/`readZipEntry`), where there's no suspend context to hook into and a blocking `.execute()` is expected - see [ZIP streaming](#zip-streaming---readzipdirectory--readzipentry) for an example.
+- **Pass `HttpUrl` directly:** `client.get`/`post`/`put`/`head` and the `GET()`/`POST()` builders all accept an `HttpUrl` object. Do not call `.toString()` on a built `HttpUrl` before passing it.
 - **Use `HttpUrl` for URL manipulation:** When parsing or extracting parts of a URL, prefer using `HttpUrl` methods (like `pathSegments` property, `encodedPathSegments`, or `queryParameter("id")`) over manual string splitting (e.g., `.split("/")`) or regex. This ensures proper separation of concerns and protects against unexpected inputs-such as URL fragments or query parameters-without you needing to manually account for all edge cases.
 - **Use `CookieInterceptor` for custom cookies:** When you need to inject custom cookies into requests, use the `lib-cookieinterceptor` dependency instead of manually adding `Cookie` headers. Manually setting the `Cookie` header overrides all cookies (including Cloudflare cookies set via WebView), breaking login and challenge solving.
 
 ### Extension call flow
 
+This section walks through the app-level behavior (pagination, caching, mandatory fields, etc.)
+behind each `KeiSource` method - see [KeiSource](#keisource) for the method signatures themselves.
+
 #### Popular Manga
 
 a.k.a. the Browse source entry point in the app (invoked by tapping on the source name).
 
-- The app calls `fetchPopularManga` which should return a `MangasPage` containing the first batch of
+- The app calls `getPopularManga` which should return a `MangasPage` containing the first batch of
   found `SManga` entries.
   - This method supports pagination. When user scrolls the manga list and more results must be fetched,
       the app calls it again with increasing `page` values (starting with `page=1`). This continues while
@@ -1029,22 +1172,25 @@ a.k.a. the Browse source entry point in the app (invoked by tapping on the sourc
 a.k.a. the Latest source entry point in the app (invoked by tapping on the "Latest" button beside
 the source name).
 
-- Enabled if `supportsLatest` is `true` for a source
-- Similar to popular manga, but should be fetching the latest entries from a source.
+- Enabled if `supportsLatest` is `true` for a source (defaults to `true` on `KeiSource`; set it to
+  `false` if the source has no separate latest listing).
+- Similar to popular manga, but should be fetching the latest entries from a source via
+  `getLatestUpdates`.
 
 #### Manga Search
 
-- When the user searches inside the app, `fetchSearchManga` will be called and the rest of the flow
-  is similar to what happens with `fetchPopularManga`.
-  - If search functionality is not available, return `Observable.just(MangasPage(emptyList(), false))`
+- When the user searches inside the app, `getSearchMangaList` will be called and the rest of the
+  flow is similar to what happens with `getPopularManga`.
+  - If search functionality is not available, return `MangasPage(emptyList(), false)`.
+  - If the query itself is a URL, `getMangaByUrl` is called instead - see [KeiSource](#keisource).
 - `getFilterList` will be called to get all filters and filter types.
 
 ##### Filters
 
 The search flow has support for filters that can be added to a `FilterList` inside the `getFilterList`
-method. When the user changes the filters' state, they will be passed to the `searchRequest`, and they
-can be iterated to create the request (by getting the `filter.state` value, where the type varies
-depending on the `Filter` used). You can check the [filter types available in Filter.kt](https://github.com/komikku-app/komikku/blob/master/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/Filter.kt)
+method. When the user changes the filters' state, they are passed into `getSearchMangaList` as its
+`filters` parameter, and can be iterated to build the request (by getting the `filter.state` value,
+where the type varies depending on the `Filter` used). You can check the [filter types available in Filter.kt](https://github.com/mihonapp/mihon/blob/main/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/Filter.kt)
 and in the table below.
 
 | Filter             | State type  | Description                                                                                                                                                              |
@@ -1073,23 +1219,25 @@ open class UriPartFilter(displayName: String, private val vals: Array<Pair<Strin
 
 #### Manga Details
 
-- When a user taps on a manga, `fetchMangaDetails` and `fetchChapterList` are called and the results are cached.
+- When a user taps on a manga, `fetchMangaUpdate` is called (with `fetchDetails`/`fetchChapters` set
+  according to what's needed) and the results are cached.
   - A `SManga` entry is identified by its `url`.
-- `fetchMangaDetails` is called to update a manga's details from when it was initialized earlier.
-  - `SManga.initialized` tells the app whether to call `fetchMangaDetails`. If you are overriding
-      `fetchMangaDetails`, ensure you set it to `true`.
+- `fetchDetails = true` asks for updated manga details.
+  - `SManga.initialized` tells the app whether details need fetching. You do not need to set it
+      yourself: `getMangaUpdate` (the `final` wrapper around `fetchMangaUpdate`) always sets it to
+      `true` on the returned manga.
   - `SManga.genre` is a string containing a list of all genres separated by `", "`.
   - `SManga.status` is an "enum" value. Refer to [the values in the `SManga` companion object](https://github.com/tachiyomiorg/extensions-lib/blob/8240b5cfecbd281bc737ac159ea7d4e5825ed3df/library/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt#L26).
   - During a backup, only `url` and `title` are stored. To restore the rest of the manga data, the
-      app calls `fetchMangaDetails`, so all fields should be (re)filled if possible.
-  - If a `SManga` is cached, `fetchMangaDetails` is only called when the user performs a manual
-      update (Swipe-to-Refresh).
-- `fetchChapterList` is called to display the chapter list.
+      app calls `fetchMangaUpdate` with `fetchDetails = true`, so all fields should be (re)filled if possible.
+  - If a `SManga` is cached, details are only re-fetched when the user performs a manual update
+      (Swipe-to-Refresh).
+- `fetchChapters = true` asks for the chapter list.
   - **The list should be sorted descending by the source order**.
-- `getMangaUrl` is called when the user taps "Open in WebView".
-  - If the source uses an API to fetch the data, consider overriding this method to return the manga's
-      absolute URL on the website instead.
-  - It defaults to the URL provided to the request in `mangaDetailsRequest`.
+- `getMangaUrl` is called when the user taps "Open in WebView". It defaults to `baseUrl + manga.url`;
+  only override it if that doesn't already resolve to the manga's page on the website. In practice
+  this is common, since `SManga.url` is recommended to hold just an ID/slug rather than a full
+  relative path - override to build the real URL from it (e.g. `"$baseUrl/manga/${manga.url}"`).
 
 #### Chapter
 
@@ -1097,39 +1245,54 @@ open class UriPartFilter(displayName: String, private val vals: Array<Pair<Strin
   **expressed in milliseconds**.
   - If you do not pass `SChapter.date_upload` and leave it at zero, the app will use the default date
       instead, but it is recommended to fill it if available.
-  - To get the time in milliseconds from a date string, you can use a `SimpleDateFormat` as in
-      the example below.
+  - For ISO-8601 date strings, prefer `kotlin.time.Instant.parseOrNull`:
 
-      ```kotlin
-      import keiyoushi.utils.tryParse
+        ```kotlin
+        import kotlin.time.Instant
 
-      chapter.date_upload = dateFormat.tryParse(dateStr)
+        chapter.date_upload = Instant.parseOrNull(dateStr)?.toEpochMilliseconds() ?: 0L
+        ```
 
-      private val dateFormat by lazy {
-          SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
-      }
-      ```
+      For any other format, prefer `java.time` (`DateTimeFormatter` + `LocalDateTime`) over
+      `SimpleDateFormat`, which is discouraged for new code:
 
-      Ensure the `SimpleDateFormat` is a class constant or variable so it is not
-      recreated for every chapter. If you need to parse or format dates in a manga description, create
-      another instance since `SimpleDateFormat` is not thread-safe.
+        ```kotlin
+        import java.time.LocalDateTime
+        import java.time.ZoneOffset
+        import java.time.format.DateTimeFormatter
+
+        chapter.date_upload = runCatching {
+            LocalDateTime.parse(dateStr, dateFormat).toInstant(ZoneOffset.UTC).toEpochMilli()
+        }.getOrDefault(0L)
+
+        private val dateFormat by lazy {
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
+        }
+        ```
+
+      Ensure the formatter is a class constant or variable so it is not recreated for every chapter
+      (a `DateTimeFormatter`, unlike `SimpleDateFormat`, is thread-safe and can safely be reused across
+      instances).
 
   - If parsing fails, return `0L` so the app uses the default date
       instead.
   - The app will overwrite the dates of existing chapters **UNLESS** `0L` is returned.
   - If the source only provides the manga's update date, assign it to the latest chapter only.
 
-- `getChapterUrl` is called when the user taps "Open in WebView" in the reader.
-  - If the source uses an API to fetch the data, consider overriding this method to return the
-      chapter's absolute URL on the website instead.
-  - It defaults to the URL provided to the request in `pageListRequest`.
+- `getChapterUrl` is called when the user taps "Open in WebView" in the reader. Like `getMangaUrl`,
+  it defaults to `baseUrl + chapter.url`; override it only when that doesn't resolve to the chapter's
+  page on the website.
 
 #### Chapter Pages
 
-- When a user opens a chapter, `fetchPageList` is called, returning a list of `Page`s.
-  `pageListRequest` and `pageListParse` are used by `fetchPageList`.
-- While a chapter is open in the reader or being downloaded, `fetchImageUrl` is called to get
-  the URL for each page of the manga if `Page.imageUrl` is empty.
+- When a user opens a chapter, `getPageList(chapter)` is called and should return the full list of
+  `Page`s directly - fetch and parse the page data in this same suspend function.
+- If a page's `imageUrl` isn't known upfront, leave `Page.imageUrl` empty; while the chapter is open
+  in the reader or being downloaded, `getImageUrl(page)` is then called lazily to resolve it. This is
+  a plain `suspend fun String` - make your request with `client` (see
+  [HTTP requests](#http-requests---okhttpclientget--post--put--head)) and return the URL directly; there's no
+  separate request/parse split to override, and you don't need to override `getImageUrl` at all if
+  every `Page.imageUrl` is already filled by `getPageList`.
 - If the source provides all `Page.imageUrl` values directly, you can fill them and leave `Page.url`
   empty. When set, `Page.url` and `Page.imageUrl` must be absolute URLs. `Page.url` may be empty if `imageUrl` is already filled.
 - The list of `Page`s should be returned already sorted; the `index` field is ignored.
@@ -1141,16 +1304,15 @@ open class UriPartFilter(displayName: String, private val vals: Array<Pair<Strin
 - **Jsoup `.text()` is already trimmed:** Calling `element.text().trim()` is redundant because Jsoup automatically normalizes and trims whitespace. Just use `element.text()`.
 - **Omit default `joinToString` separator:** The default separator for `joinToString` is already `", "`. Do not pass it explicitly. Use `joinToString { it.text() }` instead of `joinToString(", ") { it.text() }`, and `joinToString()` instead of `joinToString(", ")`.
 - **Use named parameters for `Page`:** When instantiating `Page` objects, use the named parameter for the image URL: `Page(index, imageUrl = url)` instead of passing an empty string as the second argument (`Page(index, "", url)`).
-- **Throw `UnsupportedOperationException`:** If a source uses an API and doesn't need to parse HTML for images, override `imageUrlParse(response: Response)` and throw `UnsupportedOperationException()` instead of returning an empty string. Also use this pattern for unused inherited methods.
+- **Don't override `getImageUrl` unnecessarily:** Only override it if some pages need their image URL resolved lazily (see [Chapter Pages](#chapter-pages)). If `getPageList` already fills in every `Page.imageUrl`, leave it alone - there's no unused method to stub out or throw from.
 - **Cache Regex instances:** Define `Regex` instances at the class level or in a `companion object` so they aren't recompiled on every method call.
+- **Don't cache large data in memory:** Do not hold on to large or unbounded data (e.g. a fetched manga list, parsed DTOs, an entire chapter's page list) in a top-level/class-level `var`/`val`. A source instance is long-lived for the app's lifetime, so anything stored there stays resident and never gets garbage collected. Re-fetch or re-derive the data instead; if a single value genuinely needs caching (e.g. a small auth token), scope it narrowly and keep it small.
 - **Do not hardcode `User-Agent`:** Unless absolutely necessary (e.g., to bypass Cloudflare/protection, or to retrieve a specific mobile layout/different selectors), do not hardcode a specific `User-Agent`. Calling `super.headersBuilder()` already provides the app's default User-Agent.
 - **Use `buildString { }`:** When building descriptions or dynamic strings, use Kotlin's `buildString { ... }` instead of manually instantiating a `StringBuilder()`.
 - **Media Types:** `application/json` is intrinsically UTF-8. Avoid using `application/json; charset=utf-8`. Prefer helper functions like `toJsonRequestBody()` instead of manually specifying media types (e.g., `"application/json".toMediaType()`).
 - **Use `getUrlWithoutDomain` carefully:** It can be useful when parsing target source URLs, but note a current issue with spaces-replace them with URL-encoded characters (e.g., `%20`).
 - **Manga/chapter URLs:** Prefer storing just the ID or slug in `SManga.url` and `SChapter.url`. Storing the relative URL with `setUrlWithoutDomain()` is also acceptable. Avoid absolute URLs to make future domain migrations easier.
-- **Follow `HttpSource` workflow:** Stick to the general workflow from this base class when possible; deviating may introduce unnecessary complexity.
-- **Separate custom headers:** When adding custom headers to a request (e.g., for AJAX endpoints), avoid building them inline within the `GET()` or `POST()` call. Instead, assign the modified headers to a separate variable or define them as a class-level property. This improves readability and allows for reuse across multiple requests.
-- **Do not override default `HttpSource` methods:** Avoid overriding methods like `mangaDetailsRequest` or `chapterListRequest` if they only replicate the default behavior `GET(baseUrl + manga.url, headers)`. Only override them if the source requires a different URL structure or custom headers for those specific requests.
+- **Separate custom headers:** When adding custom headers to a request (e.g., for AJAX endpoints), avoid building them inline within a `client.get`/`client.post` call. Instead, assign the modified headers to a separate variable or define them as a class-level property. This improves readability and allows for reuse across multiple requests.
 - **Configurable sources:** By implementing `ConfigurableSource`, you can add settings backed by `SharedPreferences`.
 - **Code organization:** For readability, group related methods together in your extension class (e.g., all popular manga methods, then all latest manga methods, then search methods, and so on). A logical ordering like Popular → Latest → Search → Details → Chapters → Pages → Filters → Utilities makes the class easier to navigate and maintain without needing explicit section header comments.
 - **DTO extensions:** Move mapping extensions for DTOs (like `fun MyDto.toSManga()`) into the DTO file itself to keep the main source class clean.
@@ -1170,15 +1332,13 @@ open class UriPartFilter(displayName: String, private val vals: Array<Pair<Strin
 - **Update Strategy:** For gallery sources or sources where entries are completed upon upload, set `update_strategy = UpdateStrategy.ONLY_FETCH_ONCE` to prevent unnecessary update checks.
 - **Preserving Source ID:** If you change a source's `name` or `lang`, its auto-generated `id` changes, disconnecting existing users' libraries. To prevent this, set `id` explicitly to the old value (found in `index.json`)- either in the `source {}` block or by overriding `id` in your class. See [Renaming existing sources](#renaming-existing-sources).
 - **Avoid hardcoded host checks:** When checking URLs in deep links or search overrides, avoid hardcoding the host string (e.g., `queryUrl.host == "site.com"`). This breaks if mirrors are added. Prefer dynamically checking against the source's `baseUrl`.
-- **Empty Lists vs. Exceptions:** If `pageListParse` or `chapterListParse` finds no items (e.g., a locked or empty chapter), return `emptyList()` instead of throwing a hardcoded exception. The app will display a localized error message.
+- **Empty Lists vs. Exceptions:** If `getPageList` or the chapter list from `fetchMangaUpdate` finds no items (e.g., a locked or empty chapter), return `emptyList()` instead of throwing a hardcoded exception. The app will display a localized error message.
 - **Keep comments concise and preferably in English:** We recommend writing code comments and KDocs in English to make them accessible to all contributors. Additionally, avoid verbose, redundant, or AI-generated comments explaining obvious code. Keep the code clean and self-documenting.
 
 #### Configurable Sources and Preferences
 
-- **Mirror selection preferences:** When implementing a mirror selector, save the mirror's _index_ instead of the URL string. This allows code updates to change the mirror list, and users' settings will reflect those changes automatically.
-- **Base URL getter:** When `baseUrl` is configurable via preferences, use a custom getter (e.g., `override val baseUrl: String get() = ...`) instead of `by lazy`. Using `by lazy` requires the user to restart the app for domain changes to take effect.
-- **Preference migration for base URLs:** To handle default URL changes in updates, use the `getPreferences` inline migration block to update the stored preference if the hardcoded default URL changes.
-- **Coerce mirror index:** When reading the mirror index from preferences, use `.coerceAtMost(mirrorUrls.size - 1)` to prevent `ArrayIndexOutOfBoundsException` if mirrors are removed in an update.
+- **Base URL and Mirrors:** Custom base URLs and mirror selectors are generated automatically by the `baseUrl { mirrors(...) }` and `baseUrl { custom(...) }` DSL blocks in `build.gradle.kts`. **Do not** implement these manually using `SharedPreferences` or `ListPreference`, as the KSP codegen handles preference migration, index coercion, and property overriding automatically.
+- **Other preferences:** For other custom settings (like image quality or language), implement the `ConfigurableSource` interface and use the `getPreferences()` or `getPreferencesLazy()` helpers to manage your settings.
 
 #### URL intent filter
 
@@ -1222,7 +1382,13 @@ No `AndroidManifest.xml` or `UrlActivity.kt` is needed; they are generated and p
 
 If the extension uses a theme (via `theme = "<theme_name>"`), deeplinks defined in the theme's `build.gradle.kts` are automatically merged, so individual extensions using that theme do not need to repeat shared URL patterns.
 
-Once deeplinks are declared, implement URL handling inside `fetchSearchManga`. When a deeplink is triggered, the app fires a search with the full URL as the query:
+Once deeplinks are declared, implement URL handling. When a deeplink is triggered, the app fires a
+search with the full URL as the query.
+
+> [!NOTE]
+> On `KeiSource`, just implement `getMangaByUrl(url: HttpUrl): SManga?` - it's already called
+> automatically whenever the search query is a URL. The `fetchSearchManga` override below is only
+> relevant to legacy (`libVersion = "1.4"`) sources still extending `HttpSource` directly.
 
 ```kotlin
 override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
@@ -1345,7 +1511,7 @@ plugins {
 
 keiyoushi {
     baseVersionCode = 1
-    libVersion = "1.4"
+    libVersion = "1.6"
 }
 ```
 
@@ -1354,7 +1520,7 @@ If the CMS generates URLs with a consistent structure shared by all sites built 
 ```kotlin
 keiyoushi {
     baseVersionCode = 1
-    libVersion = "1.4"
+    libVersion = "1.6"
 
     deeplink {
         path("/manga/..*")
@@ -1365,24 +1531,24 @@ keiyoushi {
 
 When no `host()` is specified in a theme `deeplink {}` block, the host is resolved at build time from each individual extension's `baseUrl`, so the same path patterns apply to every site without hardcoding hostnames in the theme.
 
-| Field             | Description                                                                                                                                                           |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `baseVersionCode` | The theme's base version code. This must be a positive integer and **incremented** whenever a change is made to the theme implementation that affects the extensions. |
-| `libVersion`      | The extension library version. Always set to `"1.4"`.                                                                                                                 |
-| `deeplink {}`     | Declares URL deeplink patterns inherited by all extensions using this theme. See [URL intent filter](#url-intent-filter).                                             |
+| Field             | Description                                                                                                                                                                                                                                                              |
+|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `baseVersionCode` | The theme's base version code. This must be a positive integer and **incremented** whenever a change is made to the theme implementation that affects the extensions.                                                                                                    |
+| `libVersion`      | The extension library version. New themes must set this to `"1.6"` and have their main class extend `KeiSource`. `"1.4"` is legacy and only found in themes not yet migrated. Every extension using the theme inherits this value and must not set its own `libVersion`. |
+| `deeplink {}`     | Declares URL deeplink patterns inherited by all extensions using this theme. See [URL intent filter](#url-intent-filter).                                                                                                                                                |
 
 #### Theme main class
 
-The theme's main class (e.g., `<ThemeName>.kt`) contains the default implementation for the source sites. It should be declared as an `abstract class` extending `HttpSource`, allowing individual extensions to inherit and override its properties and methods.
+The theme's main class (e.g., `<ThemeName>.kt`) contains the default implementation for the source sites. It should be declared as an `abstract class` extending `KeiSource` (or `HttpSource` for themes still on `libVersion = "1.4"`), allowing individual extensions to inherit and override its properties and methods.
 
 ```kotlin
 package eu.kanade.tachiyomi.multisrc.example // Replace 'example' with your theme name
 
-import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.source.KeiSource
 
-abstract class ExampleTheme : HttpSource() {
+abstract class ExampleTheme : KeiSource() {
 
-    // name, lang, and baseUrl are inherited from HttpSource. They are automatically
+    // name, lang, and baseUrl are inherited from KeiSource/HttpSource. They are automatically
     // overridden and injected by the KSP generator via each extension's `source {}`
     // block. Do not declare them in the constructor.
 
@@ -1402,7 +1568,7 @@ keiyoushi {
     theme = "example" // Replace with your actual theme name
     versionCode = 1
     contentWarning = ContentWarning.NSFW
-    libVersion = "1.4"
+    libVersion = "1.6" // Must match the theme's own libVersion
 
     source {
         lang = "en"
@@ -1544,8 +1710,8 @@ For that, add this code inside your source class:
 package eu.kanade.tachiyomi.extension.en.mysource
 
 import android.annotation.SuppressLint
-import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.annotation.Source
+import keiyoushi.source.KeiSource
 import okhttp3.OkHttpClient
 import java.net.InetSocketAddress
 import java.net.Proxy
@@ -1556,7 +1722,7 @@ import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
 @Source
-abstract class MySource : HttpSource() {
+abstract class MySource : KeiSource() {
     private fun OkHttpClient.Builder.ignoreAllSSLErrors(): OkHttpClient.Builder {
         val naiveTrustManager = @SuppressLint("CustomX509TrustManager")
         object : X509TrustManager {
@@ -1575,10 +1741,9 @@ abstract class MySource : HttpSource() {
         return this
     }
 
-    override val client: OkHttpClient = network.client.newBuilder()
-        .ignoreAllSSLErrors()
-        .proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress("10.0.2.2", 8080)))
-        .build()
+    override fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder =
+        ignoreAllSSLErrors()
+            .proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress("10.0.2.2", 8080)))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository contains extension catalogues which are compatible with [Komikku
 * Otherwise, copy & paste the following URL:
 
 ```html
-https://raw.githubusercontent.com/yuzono/cursed-manga-repo/repo/index.min.json
+https://github.com/yuzono/cursed-manga-repo/raw/repo/index.pb
 ```
 
 ## Requests

--- a/common/proguard-rules.pro
+++ b/common/proguard-rules.pro
@@ -1,5 +1,5 @@
 #-dontobfuscate
--dontoptimize
+#-dontoptimize
 
 ## Partially based on https://android.googlesource.com/platform/tools/base/+/refs/heads/mirror-goog-studio-main/build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt
 

--- a/common/proguard-rules.pro
+++ b/common/proguard-rules.pro
@@ -24,7 +24,7 @@
 # resolved with reflection at runtime, so the Signature attribute is needed.
 # https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#troubleshooting-gson-gson
 -keepattributes Signature
--keep class * extends uy.kohesive.injekt.api.FullTypeReference
+-keep,allowshrinking,allowoptimization,allowobfuscation class * extends uy.kohesive.injekt.api.FullTypeReference
 
 # kotlinx-serialization — runtime keeps required for @Serializable types and their
 # generated $serializer companions.

--- a/compiler/src/main/kotlin/keiyoushi/processor/SourceProcessor.kt
+++ b/compiler/src/main/kotlin/keiyoushi/processor/SourceProcessor.kt
@@ -33,12 +33,14 @@ data class PartialLocaleStrings(
     val mirrorTitle: String? = null,
     val customUrlTitle: String? = null,
     val customUrlDialogMessage: String? = null,
+    val filterFetchHint: String? = null,
 )
 
 data class LocaleStrings(
     val mirrorTitle: String,
     val customUrlTitle: String,
     val customUrlDialogMessage: String,
+    val filterFetchHint: String,
 )
 
 @Serializable
@@ -63,6 +65,7 @@ data class SourceDef(
 )
 
 private const val HTTP_SOURCE = "eu.kanade.tachiyomi.source.online.HttpSource"
+private const val KEI_SOURCE = "keiyoushi.source.KeiSource"
 
 private fun KSClassDeclaration.derivesFromHttpSource(): Boolean =
     getAllSuperTypes().any { it.declaration.qualifiedName?.asString() == HTTP_SOURCE }
@@ -96,6 +99,7 @@ class SourceProcessor(
             mirrorTitle = locale?.mirrorTitle ?: en.mirrorTitle!!,
             customUrlTitle = locale?.customUrlTitle ?: en.customUrlTitle!!,
             customUrlDialogMessage = locale?.customUrlDialogMessage ?: en.customUrlDialogMessage!!,
+            filterFetchHint = locale?.filterFetchHint ?: en.filterFetchHint!!,
         )
     }
 
@@ -144,6 +148,7 @@ class SourceProcessor(
             .mapNotNull { it.declaration.qualifiedName?.asString() }
             .toSet()
         val isConfigurable = "eu.kanade.tachiyomi.source.ConfigurableSource" in superTypeNames
+        val isKeiSource = KEI_SOURCE in superTypeNames
 
         if (HTTP_SOURCE !in superTypeNames) {
             logger.error("@Source class must derive from HttpSource", annotated)
@@ -164,9 +169,9 @@ class SourceProcessor(
 
         val isConcrete = Modifier.ABSTRACT !in annotated.modifiers
         val generatedClass = if (sources.size == 1 && !isConcrete) {
-            buildSingleSourceClass(annotatedClass, sources.single(), isConfigurable, overridden, annotated, fileProps)
+            buildSingleSourceClass(annotatedClass, sources.single(), isConfigurable, isKeiSource, overridden, annotated, fileProps)
         } else {
-            buildSourceFactoryClass(annotatedClass, sources, isConfigurable, overridden, annotated, fileProps)
+            buildSourceFactoryClass(annotatedClass, sources, isConfigurable, isKeiSource, overridden, annotated, fileProps)
         }
 
         FileSpec.builder(pkg, "ExtensionGenerated")
@@ -182,19 +187,21 @@ class SourceProcessor(
         annotatedClass: ClassName,
         source: SourceDef,
         isConfigurable: Boolean,
+        isKeiSource: Boolean,
         overridden: Set<String>,
         node: KSClassDeclaration,
         fileProps: MutableList<PropertySpec>,
     ): TypeSpec = TypeSpec.classBuilder("ExtensionGenerated")
         .addModifiers(KModifier.INTERNAL)
         .superclass(annotatedClass)
-        .applySourceMembers(source, "", fileProps, isConfigurable, overridden, node)
+        .applySourceMembers(source, "", fileProps, isConfigurable, isKeiSource, overridden, node)
         .build()
 
     private fun buildSourceFactoryClass(
         annotatedClass: ClassName,
         sources: List<SourceDef>,
         isConfigurable: Boolean,
+        isKeiSource: Boolean,
         overridden: Set<String>,
         node: KSClassDeclaration,
         fileProps: MutableList<PropertySpec>,
@@ -226,7 +233,7 @@ class SourceProcessor(
                             "%L,\n",
                             TypeSpec.anonymousClassBuilder()
                                 .superclass(annotatedClass)
-                                .applySourceMembers(source, index.toString(), fileProps, isConfigurable, overridden, node)
+                                .applySourceMembers(source, index.toString(), fileProps, isConfigurable, isKeiSource, overridden, node)
                                 .build(),
                         )
                     }
@@ -310,10 +317,23 @@ class SourceProcessor(
         suffix: String,
         fileProps: MutableList<PropertySpec>,
         isConfigurable: Boolean,
+        isKeiSource: Boolean,
         overridden: Set<String>,
         node: KSClassDeclaration,
     ): TypeSpec.Builder = apply {
         val className = node.simpleName.asString()
+
+        if (isKeiSource) {
+            if ("filterFetchHint" in overridden) {
+                logger.error("filterFetchHint is owned by the DSL; remove 'override val filterFetchHint' from $className (it is generated per language from core/translations)", node)
+            } else {
+                addProperty(
+                    PropertySpec.builder("filterFetchHint", String::class.asClassName(), KModifier.OVERRIDE, KModifier.PROTECTED)
+                        .getter(FunSpec.getterBuilder().addStatement("return %S", stringsForLang(source.lang).filterFetchHint).build())
+                        .build(),
+                )
+            }
+        }
 
         if ("name" in overridden) {
             logger.warn("name is provided by $className; skipping generated name (DSL name is used for metadata only)", node)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -20,7 +20,9 @@ android {
 
 dependencies {
     compileOnly(libs.bundles.common)
+    compileOnly(libs.tachiyomi.lib.v16)
 
     testImplementation(libs.bundles.common)
+    testImplementation(libs.tachiyomi.lib.v16)
     testImplementation(libs.junit)
 }

--- a/core/src/main/kotlin/keiyoushi/network/CacheControlInterceptor.kt
+++ b/core/src/main/kotlin/keiyoushi/network/CacheControlInterceptor.kt
@@ -1,0 +1,32 @@
+package keiyoushi.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Widens a cacheable response's `Cache-Control` to the request's own `max-age` when the origin
+ * didn't already declare a usable one, so OkHttp's disk cache doesn't revalidate on every access.
+ */
+internal class CacheControlInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        val requestMaxAge = request.cacheControl.maxAgeSeconds
+        val cacheControl = response.header("Cache-Control")
+        if (requestMaxAge <= 0 || !response.isSuccessful || cacheControl == null || !shouldOverride(cacheControl)) {
+            return response
+        }
+
+        return response.newBuilder()
+            .header("Cache-Control", "public, max-age=$requestMaxAge")
+            .build()
+    }
+
+    private fun shouldOverride(cacheControl: String): Boolean {
+        val directives = cacheControl.split(",").map { it.trim().lowercase() }
+        if (directives.any { it == "no-store" || it == "no-cache" || it == "private" }) return false
+        if (directives.any { it.startsWith("max-age=") }) return false
+        return true
+    }
+}

--- a/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
+++ b/core/src/main/kotlin/keiyoushi/network/RateLimit.kt
@@ -1,6 +1,7 @@
 package keiyoushi.network
 
 import android.os.SystemClock
+import keiyoushi.utils.firstInstanceOrNull
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
@@ -15,40 +16,11 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-class RateLimitBuilder internal constructor(
-    private val base: OkHttpClient.Builder,
-    private val rules: List<RateLimitRule> = emptyList(),
-) {
-    /**
-     * Adds a rate limit rule. Rules are evaluated in order, first match wins —
-     * define more specific rules before broader ones. Call [build] to finalize.
-     *
-     * @param permits     Requests allowed per [period].
-     * @param period      Sliding-window duration.
-     * @param interval    Minimum gap between consecutive dispatches. Smooths bursts —
-     *                    `permits=10, interval=100.ms` allows 10/s but spaced ≥100ms apart.
-     * @param shouldLimit Whether this rule applies to a given URL.
-     */
-    fun rateLimit(
-        permits: Int,
-        period: Duration = 1.seconds,
-        interval: Duration = Duration.ZERO,
-        shouldLimit: (HttpUrl) -> Boolean = { true },
-    ) = RateLimitBuilder(base, rules + RateLimitRule(permits, period, interval, shouldLimit))
-
-    fun build(): OkHttpClient = base
-        .addInterceptor(RateLimitInterceptor.TaggingInterceptor)
-        .addNetworkInterceptor(RateLimitInterceptor(rules))
-        .build()
-}
-
 /**
- * Begins a rate-limited client configuration. Chain further [RateLimitBuilder.rateLimit] calls
- * for additional rules, then call [RateLimitBuilder.build] to finalize — all other client
- * configuration should be done on the [OkHttpClient.Builder] before calling this.
- *
- * The first rule whose [shouldLimit] matches the request URL is applied;
- * remaining rules are skipped. Define more specific rules before broader ones:
+ * Adds a rate limit rule to the builder's [RateLimitInterceptor], creating it if this is the
+ * first [rateLimit] call. Chain further calls for additional rules — the first rule whose
+ * [shouldLimit] matches the request URL is applied, remaining rules are skipped, so define more
+ * specific rules before broader ones:
  * ```
  * OkHttpClient.Builder()
  *     .rateLimit(5)  { it.host == "api.manga.example" }
@@ -67,7 +39,20 @@ fun OkHttpClient.Builder.rateLimit(
     period: Duration = 1.seconds,
     interval: Duration = Duration.ZERO,
     shouldLimit: (HttpUrl) -> Boolean = { true },
-): RateLimitBuilder = RateLimitBuilder(this, listOf(RateLimitRule(permits, period, interval, shouldLimit)))
+): OkHttpClient.Builder = apply {
+    val rule = RateLimitRule(permits, period, interval, shouldLimit)
+
+    val existing = networkInterceptors().firstInstanceOrNull<RateLimitInterceptor>()
+    if (existing != null) {
+        existing.addRule(rule)
+        return@apply
+    }
+
+    if (RateLimitInterceptor.TaggingInterceptor !in interceptors()) {
+        addInterceptor(RateLimitInterceptor.TaggingInterceptor)
+    }
+    addNetworkInterceptor(RateLimitInterceptor(rule))
+}
 
 internal class RateLimitRule(
     val permits: Int,
@@ -76,8 +61,8 @@ internal class RateLimitRule(
     val shouldLimit: (HttpUrl) -> Boolean,
 )
 
-private class RateLimitInterceptor(
-    rules: List<RateLimitRule>,
+internal class RateLimitInterceptor(
+    rule: RateLimitRule,
 ) : Interceptor {
 
     private class RateLimitTag(
@@ -106,7 +91,11 @@ private class RateLimitInterceptor(
         var lastDispatchTime: Duration? = null
     }
 
-    private val rateLimits = rules.map { RateLimit(it.permits, it.period, it.interval, it.shouldLimit) }
+    private val rateLimits = mutableListOf(RateLimit(rule.permits, rule.period, rule.interval, rule.shouldLimit))
+
+    fun addRule(rule: RateLimitRule) {
+        rateLimits += RateLimit(rule.permits, rule.period, rule.interval, rule.shouldLimit)
+    }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val call = chain.call()

--- a/core/src/main/kotlin/keiyoushi/source/KeiSource.kt
+++ b/core/src/main/kotlin/keiyoushi/source/KeiSource.kt
@@ -182,13 +182,25 @@ abstract class KeiSource : HttpSource() {
      * @param url The [HttpUrl] of the manga.
      * @return The [SManga] details if resolved successfully, or null.
      */
-    abstract suspend fun getMangaByUrl(url: HttpUrl): SManga?
+    protected open suspend fun getMangaByUrl(url: HttpUrl): SManga? = throw Exception("getMangaByUrl not implemented")
+
+    /**
+     * Fetches a page of manga list from given url.
+     * Not needed for most sources
+     *
+     * @param url the [HttpUrl] of a manga list
+     * @param page the page number to retrieve
+     * @return a [MangasPage] containing the list of manga and whether there is a next page
+     */
+    protected open suspend fun getMangasByUrl(url: HttpUrl, page: Int): MangasPage {
+        val manga = getMangaByUrl(url)
+
+        return MangasPage(listOfNotNull(manga), hasNextPage = false)
+    }
 
     final override suspend fun getSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
         query.toHttpUrlOrNull()?.also { url ->
-            val manga = getMangaByUrl(url)
-
-            return MangasPage(listOfNotNull(manga), hasNextPage = false)
+            return getMangasByUrl(url, page)
         }
 
         return getSearchMangaList(page, query, filters)
@@ -378,7 +390,7 @@ abstract class KeiSource : HttpSource() {
      *
      * Only works on Komikku
      */
-    override val supportsRelatedMangas get() = true
+    override val supportsRelatedMangas get() = false
 
     /**
      * Whether to fall back to searching the source by the manga's title if a direct related manga list is unavailable.
@@ -401,7 +413,7 @@ abstract class KeiSource : HttpSource() {
      * @param manga The reference manga.
      * @return A list of related [SManga].
      */
-    abstract override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga>
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = emptyList()
 
     /**
      * Returns the absolute web URL for the provided manga.
@@ -410,7 +422,7 @@ abstract class KeiSource : HttpSource() {
      * @param manga The manga.
      * @return The absolute URL of the manga.
      */
-    abstract override fun getMangaUrl(manga: SManga): String
+    override fun getMangaUrl(manga: SManga): String = baseUrl + manga.url
 
     /**
      * Returns the absolute web URL for the provided chapter.
@@ -419,7 +431,7 @@ abstract class KeiSource : HttpSource() {
      * @param chapter The chapter.
      * @return The absolute URL of the chapter.
      */
-    abstract override fun getChapterUrl(chapter: SChapter): String
+    override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url
 
     /**
      * Get the list of pages a chapter has. Pages should be returned

--- a/core/src/main/kotlin/keiyoushi/source/KeiSource.kt
+++ b/core/src/main/kotlin/keiyoushi/source/KeiSource.kt
@@ -1,0 +1,512 @@
+package keiyoushi.source
+
+import android.util.Log
+import com.squareup.zstd.okio.zstdCompress
+import com.squareup.zstd.okio.zstdDecompress
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
+import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.network.CacheControlInterceptor
+import keiyoushi.network.RateLimitInterceptor
+import keiyoushi.utils.applicationContext
+import keiyoushi.utils.firstInstanceOrNull
+import keiyoushi.utils.jsonInstance
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.okio.decodeFromBufferedSource
+import kotlinx.serialization.json.okio.encodeToBufferedSink
+import okhttp3.CompressionInterceptor
+import okhttp3.Gzip
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import okhttp3.brotli.Brotli
+import okhttp3.brotli.BrotliInterceptor
+import okhttp3.zstd.Zstd
+import okio.buffer
+import okio.sink
+import okio.source
+import rx.Observable
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.days
+
+abstract class KeiSource : HttpSource() {
+
+    // make `headers` not lazy
+    init {
+        val delegate = object : Lazy<Headers> {
+            override val value: Headers get() = headersBuilder().build()
+            override fun isInitialized(): Boolean = true
+        }
+
+        HttpSource::class.java.getDeclaredField($$"headers$delegate").apply {
+            isAccessible = true
+            set(this@KeiSource, delegate)
+        }
+    }
+
+    /**
+     * Customizes the OkHttpClient builder. Subclasses can override this to configure timeouts,
+     * add application/network interceptors, or configure cookie/cache/dns settings.
+     */
+    protected open fun OkHttpClient.Builder.configureClient(): OkHttpClient.Builder = this
+
+    final override val client: OkHttpClient by lazy {
+        network.client.newBuilder().apply {
+            with(interceptors()) {
+                check(
+                    this.any { it.javaClass.simpleName == "UncaughtExceptionInterceptor" },
+                ) {
+                    "UncaughtExceptionInterceptor must be present in default client"
+                }
+
+                check(
+                    this.any { it.javaClass.simpleName == "UserAgentInterceptor" },
+                ) {
+                    "UserAgentInterceptor must be present in default client"
+                }
+
+                check(
+                    this.any { it.javaClass.simpleName == "CloudflareInterceptor" },
+                ) {
+                    "CloudflareInterceptor must be present in default client"
+                }
+            }
+
+            with(networkInterceptors()) {
+                check(
+                    this.none { it.javaClass.simpleName == "IgnoreGzipInterceptor" },
+                ) {
+                    "IgnoreGzipInterceptor must not be present in default client"
+                }
+
+                check(
+                    this.none { it is BrotliInterceptor },
+                ) {
+                    "BrotliInterceptor must not be present in default client"
+                }
+            }
+
+            configureClient()
+
+            // cf interceptor below source specific interceptors
+            interceptors().apply {
+                // some sources remove the cf interceptor, so do nullable check
+                val cloudflareInterceptor = firstOrNull { it.javaClass.simpleName == "CloudflareInterceptor" }
+                if (cloudflareInterceptor != null) {
+                    remove(cloudflareInterceptor)
+                    add(cloudflareInterceptor)
+                }
+            }
+
+            // last application interceptor
+            addInterceptor(CompressionInterceptor(Brotli, Gzip, Zstd))
+
+            // allow caching when server doesn't explicitly say anything
+            addNetworkInterceptor(CacheControlInterceptor())
+
+            // keep the source's rate limiter as the last network interceptor
+            networkInterceptors().apply {
+                val rateLimiter = firstInstanceOrNull<RateLimitInterceptor>()
+                if (rateLimiter != null) {
+                    remove(rateLimiter)
+                    add(rateLimiter)
+                }
+            }
+        }.build()
+    }
+
+    /**
+     * Customizes the base Headers builder. Subclasses can override this to append source-specific
+     * headers.
+     *
+     * Note: "User-Agent", "Referer", and "Origin" are already added by default.
+     */
+    protected open fun Headers.Builder.configureHeaders(): Headers.Builder = this
+
+    final override fun headersBuilder() = super.headersBuilder()
+        .set("Referer", "$baseUrl/")
+        .set("Origin", baseUrl)
+        .configureHeaders()
+
+    /**
+     * Fetches a page of popular manga from the source.
+     *
+     * @param page The page number to retrieve.
+     * @return A [MangasPage] containing the list of manga and whether there is a next page.
+     */
+    abstract override suspend fun getPopularManga(page: Int): MangasPage
+
+    /**
+     * Whether the source supports fetching a list of latest manga updates.
+     */
+    override val supportsLatest get() = true
+
+    /**
+     * Fetches a page of latest manga updates from the source.
+     *
+     * @param page The page number to retrieve.
+     * @return A [MangasPage] containing the list of updated manga and whether there is a next page.
+     */
+    abstract override suspend fun getLatestUpdates(page: Int): MangasPage
+
+    /**
+     * Fetches a page of manga matching the query and filters.
+     *
+     * @param page The page number to retrieve.
+     * @param query The search query.
+     * @param filters The list of filters to apply.
+     * @return A [MangasPage] containing the matching manga and whether there is a next page.
+     */
+    abstract suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage
+
+    /**
+     * Fetches details of a single manga directly using its HTTP URL.
+     * Used for resolving URL search queries in the browser or search bar.
+     *
+     * @param url The [HttpUrl] of the manga.
+     * @return The [SManga] details if resolved successfully, or null.
+     */
+    abstract suspend fun getMangaByUrl(url: HttpUrl): SManga?
+
+    final override suspend fun getSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
+        query.toHttpUrlOrNull()?.also { url ->
+            val manga = getMangaByUrl(url)
+
+            return MangasPage(listOfNotNull(manga), hasNextPage = false)
+        }
+
+        return getSearchMangaList(page, query, filters)
+    }
+
+    private val filterFetchInFlight = AtomicBoolean(false)
+    private val filterFetchAttemptCount = AtomicInteger(0)
+    private val maxFilterFetchAttempts = 3
+    private val filterCacheDir: File by lazy {
+        applicationContext.cacheDir.resolve("source_$id").apply { mkdirs() }
+    }
+    private val filterCacheFile: File by lazy {
+        filterCacheDir.resolve("filters.json.zst")
+    }
+
+    /**
+     * Whether this source fetches its filters from the network
+     * implement [fetchFilterData] when true
+     */
+    protected open val supportsFilterFetching: Boolean get() = false
+
+    /**
+     * Text shown as a filter header hint while filters are unavailable
+     * Do not override by hand
+     */
+    protected open val filterFetchHint: String get() = "Tap 'Reset' to load filters"
+
+    /**
+     * Fetches filter data from the network.
+     *
+     * Only called when [supportsFilterFetching] is true, on a background coroutine.
+     * Implementations should perform whatever requests are necessary and return
+     * the result as a [JsonElement]
+     *
+     * Throwing is treated as a failed attempt and retried (see [maxFilterFetchAttempts]);
+     */
+    protected open suspend fun fetchFilterData(): JsonElement = JsonNull
+
+    /**
+     * Builds a [FilterList] from previously cached/fetched filter data.
+     *
+     * This is called synchronously every time [getFilterList] is invoked, so it must be
+     * fast and must NOT perform I/O or network requests — only convert [data] into filters.
+     *
+     * @param data The cached filter data or null when no data is available yet
+     * (e.g. first launch or fetching failed or cache deleted).
+     */
+    protected open fun getFilterList(data: JsonElement?): FilterList = FilterList()
+
+    final override fun getFilterList(): FilterList {
+        if (!supportsFilterFetching) return getFilterList(data = null)
+
+        val (cached, isFresh) = readFilterCacheState()
+        val parsed = cached?.let {
+            try {
+                getFilterList(it)
+            } catch (e: Exception) {
+                Log.e(name, "Failed to parse filter data", e)
+                null
+            }
+        }
+
+        if (parsed == null || !isFresh) {
+            triggerBackgroundFilterFetch()
+        }
+
+        if (parsed != null) return parsed
+
+        return FilterList(
+            buildList {
+                addAll(getFilterList(data = null))
+                if (isNotEmpty()) {
+                    add(Filter.Separator())
+                }
+                add(Filter.Header(filterFetchHint))
+            },
+        )
+    }
+
+    private data class FilterCacheState(val data: JsonElement?, val isFresh: Boolean)
+
+    private fun readFilterCacheState(): FilterCacheState {
+        val file = filterCacheFile
+        if (!file.exists()) return FilterCacheState(data = null, isFresh = false)
+
+        val age = System.currentTimeMillis() - file.lastModified()
+        val isFresh = age <= 3.days.inWholeMilliseconds
+
+        val data = try {
+            file.source().zstdDecompress().buffer().use { source ->
+                jsonInstance.decodeFromBufferedSource(JsonElement.serializer(), source)
+            }
+        } catch (_: Exception) {
+            null
+        }
+
+        return FilterCacheState(data, isFresh)
+    }
+
+    private fun writeFilterCache(data: JsonElement) {
+        filterCacheDir.mkdirs()
+        val tmpFile = File.createTempFile("filters", ".tmp", filterCacheDir)
+
+        try {
+            tmpFile.sink().zstdCompress().buffer().use { sink ->
+                jsonInstance.encodeToBufferedSink(JsonElement.serializer(), data, sink)
+            }
+
+            if (!tmpFile.renameTo(filterCacheFile)) {
+                filterCacheFile.delete()
+                if (!tmpFile.renameTo(filterCacheFile)) {
+                    throw IOException("Failed to move $tmpFile to $filterCacheFile")
+                }
+            }
+        } finally {
+            tmpFile.delete()
+        }
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun triggerBackgroundFilterFetch() {
+        if (filterFetchAttemptCount.get() >= maxFilterFetchAttempts) return
+        if (!filterFetchInFlight.compareAndSet(false, true)) return
+
+        GlobalScope.launch(Dispatchers.IO) {
+            try {
+                val data = fetchFilterData()
+                writeFilterCache(data)
+                filterFetchAttemptCount.set(0)
+            } catch (e: Exception) {
+                Log.e(name, "Failed to fetch filter data", e)
+                filterFetchAttemptCount.incrementAndGet()
+            } finally {
+                filterFetchInFlight.set(false)
+            }
+        }
+    }
+
+    /**
+     * Fetches updated information for a manga.
+     *
+     * Depending on the provided flags or source availability, this may include
+     * updated manga metadata, available chapters, or both.
+     *
+     * If a value is not requested, the existing provided value can be returned as-is.
+     * The host app may apply any returned updates regardless of the flags,
+     * so it’s best to avoid returning unintended or inaccurate data.
+     *
+     * @param manga The manga to fetch updates for.
+     * @param chapters Existing chapters of the manga
+     * @param fetchDetails Whether to include updated manga details.
+     * @param fetchChapters Whether to include available chapters.
+     */
+    abstract suspend fun fetchMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate
+
+    private val updatesInFlight = ConcurrentHashMap<String, Boolean>()
+
+    final override suspend fun getMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        check(fetchDetails || fetchChapters) { "getMangaUpdate called with nothing to fetch (fetchDetails=false, fetchChapters=false)" }
+
+        check(updatesInFlight.putIfAbsent(manga.url, true) == null) { "getMangaUpdate must not be called concurrently for same manga" }
+
+        try {
+            val update = fetchMangaUpdate(manga, chapters, fetchDetails, fetchChapters)
+
+            return SMangaUpdate(
+                manga = update.manga.apply { initialized = true },
+                chapters = update.chapters,
+            )
+        } finally {
+            updatesInFlight.remove(manga.url)
+        }
+    }
+
+    /**
+     * Whether the source supports retrieving related manga.
+     *
+     * Only works on Komikku
+     */
+    override val supportsRelatedMangas get() = true
+
+    /**
+     * Whether to fall back to searching the source by the manga's title if a direct related manga list is unavailable.
+     *
+     * Only works on Komikku
+     */
+    protected open val supportRelatedMangasBySearch get() = false
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override val disableRelatedMangasBySearch get() = !supportRelatedMangasBySearch
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override val disableRelatedMangas get() = false
+
+    /**
+     * Fetches a list of related manga for the specified manga.
+     *
+     * Only works on Komikku
+     *
+     * @param manga The reference manga.
+     * @return A list of related [SManga].
+     */
+    abstract override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga>
+
+    /**
+     * Returns the absolute web URL for the provided manga.
+     * Used for the WebView ("Open in WebView") and sharing features.
+     *
+     * @param manga The manga.
+     * @return The absolute URL of the manga.
+     */
+    abstract override fun getMangaUrl(manga: SManga): String
+
+    /**
+     * Returns the absolute web URL for the provided chapter.
+     * Used for the WebView ("Open in WebView") and sharing features.
+     *
+     * @param chapter The chapter.
+     * @return The absolute URL of the chapter.
+     */
+    abstract override fun getChapterUrl(chapter: SChapter): String
+
+    /**
+     * Get the list of pages a chapter has. Pages should be returned
+     * in the expected order; the index is ignored.
+     *
+     * @param chapter the chapter.
+     * @return the pages for the chapter.
+     */
+    abstract override suspend fun getPageList(chapter: SChapter): List<Page>
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION")
+    final override fun fetchPopularManga(page: Int): Observable<MangasPage> = super.fetchPopularManga(page)
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun popularMangaRequest(page: Int) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun popularMangaParse(response: Response) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION")
+    final override fun fetchLatestUpdates(page: Int): Observable<MangasPage> = super.fetchLatestUpdates(page)
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun latestUpdatesRequest(page: Int) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun latestUpdatesParse(response: Response) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION")
+    final override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> = super.fetchSearchManga(page, query, filters)
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun searchMangaRequest(page: Int, query: String, filters: FilterList) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun searchMangaParse(response: Response) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION")
+    final override fun fetchMangaDetails(manga: SManga): Observable<SManga> = super.fetchMangaDetails(manga)
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun mangaDetailsRequest(manga: SManga) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun mangaDetailsParse(response: Response) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun relatedMangaListRequest(manga: SManga) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun relatedMangaListParse(response: Response): List<SManga> = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION")
+    final override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = super.fetchChapterList(manga)
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun chapterListRequest(manga: SManga) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun chapterListParse(response: Response) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION")
+    final override fun prepareNewChapter(chapter: SChapter, manga: SManga) = super.prepareNewChapter(chapter, manga)
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION")
+    final override fun fetchPageList(chapter: SChapter): Observable<List<Page>> = super.fetchPageList(chapter)
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun pageListRequest(chapter: SChapter) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun pageListParse(response: Response) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    @Suppress("DEPRECATION")
+    final override fun fetchImageUrl(page: Page): Observable<String> = super.fetchImageUrl(page)
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun imageUrlRequest(page: Page) = throw UnsupportedOperationException()
+
+    @Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+    final override fun imageUrlParse(response: Response) = throw UnsupportedOperationException()
+}

--- a/core/src/main/kotlin/keiyoushi/utils/Context.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Context.kt
@@ -4,4 +4,4 @@ import android.app.Application
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
-val applicationContext: Application get() = Injekt.get()
+val applicationContext: Application = Injekt.get()

--- a/core/src/main/kotlin/keiyoushi/utils/WebView.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/WebView.kt
@@ -1,0 +1,602 @@
+package keiyoushi.utils
+
+import android.annotation.SuppressLint
+import android.content.res.Resources
+import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.ConsoleMessage
+import android.webkit.JavascriptInterface
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import eu.kanade.tachiyomi.network.NetworkHelper
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.IOException
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/** Thrown when the WebView's render process crashes or is killed mid-run. */
+class RenderProcessGoneException internal constructor(
+    didCrash: Boolean,
+) : Exception(
+    if (didCrash) "WebView render process crashed" else "WebView render process was killed",
+)
+
+/**
+ * Thrown by [runWebView] on timeout. Deliberately a plain [Exception] rather than a
+ * [kotlinx.coroutines.CancellationException], so callers see a failure instead of a
+ * silently swallowed cancellation.
+ */
+class WebViewTimeoutException internal constructor(
+    timeout: Duration,
+) : Exception("Timed out waiting for WebView after $timeout")
+
+/**
+ * DSL for configuring and driving a single [runWebView] run.
+ *
+ * Threading: page/navigation hooks and [poll] run on the main thread; [interceptRequest]
+ * and [jsBridge] handlers run on WebView background threads. An exception thrown from any
+ * callback fails the run via [reject].
+ */
+@SuppressLint("SetJavaScriptEnabled")
+class WebViewScope<T> internal constructor(
+    private val webView: WebView,
+    private val deferred: CompletableDeferred<T>,
+) {
+    internal val pageStartedHooks = CopyOnWriteArrayList<(String) -> Unit>()
+    internal val pageFinishedHooks = CopyOnWriteArrayList<(String) -> Unit>()
+    internal val receivedErrorHooks = CopyOnWriteArrayList<(WebResourceRequest, WebResourceError) -> Unit>()
+    internal val bridgeNames = CopyOnWriteArrayList<String>()
+
+    @Volatile
+    internal var interceptHook: ((WebResourceRequest) -> WebResourceResponse?)? = null
+
+    @Volatile
+    internal var destroyed = false
+
+    @Volatile
+    internal var renderDead = false
+
+    private val loaded = AtomicBoolean(false)
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /** Completes [runWebView] with [value]. First completion wins; later calls are no-ops. */
+    fun resolve(value: T) {
+        deferred.complete(value)
+    }
+
+    /** Completes [runWebView] by throwing [error]. No-op if already completed. */
+    fun reject(error: Throwable) {
+        deferred.completeExceptionally(error)
+    }
+
+    var javaScriptEnabled: Boolean by setting({ javaScriptEnabled }, { javaScriptEnabled = it })
+    var domStorageEnabled: Boolean by setting({ domStorageEnabled }, { domStorageEnabled = it })
+    var blockImages: Boolean by setting({ blockNetworkImage }, { blockNetworkImage = it })
+    var useWideViewPort: Boolean by setting({ useWideViewPort }, { useWideViewPort = it })
+    var loadWithOverviewMode: Boolean by setting({ loadWithOverviewMode }, { loadWithOverviewMode = it })
+    var userAgent: String by setting({ userAgentString }, { userAgentString = it })
+
+    /** Routes all WebView network requests through OkHttp client instead of WebView's own network stack. */
+    var useOkHttpNetwork: Boolean = false
+
+    /** Runs [block] on every navigation start. */
+    fun onPageStarted(block: (url: String) -> Unit) {
+        pageStartedHooks += { url ->
+            try {
+                block(url)
+            } catch (t: Throwable) {
+                reject(t)
+            }
+        }
+    }
+
+    /**
+     * Runs [block] on every navigation finish. Note that this can fire multiple times for a
+     * single page (redirects, SPA navigations, iframes).
+     */
+    fun onPageFinished(block: (url: String) -> Unit) {
+        pageFinishedHooks += { url ->
+            try {
+                block(url)
+            } catch (t: Throwable) {
+                reject(t)
+            }
+        }
+    }
+
+    /** Runs [block] on navigation failures (DNS/SSL/network errors). */
+    fun onReceivedError(block: (request: WebResourceRequest, error: WebResourceError) -> Unit) {
+        receivedErrorHooks += { request, error ->
+            try {
+                block(request, error)
+            } catch (t: Throwable) {
+                reject(t)
+            }
+        }
+    }
+
+    /**
+     * Registers [block] to inspect/replace/block every resource request; return null to let a
+     * request proceed normally. Runs on a WebView background thread. Can only be registered once.
+     */
+    fun interceptRequest(block: (WebResourceRequest) -> WebResourceResponse?) {
+        check(interceptHook == null) { "interceptRequest already registered" }
+        interceptHook = { request ->
+            try {
+                block(request)
+            } catch (t: Throwable) {
+                reject(t)
+                null
+            }
+        }
+    }
+
+    /**
+     * Exposes `window.$name.post(message)` to the page, invoking [handler] with the message.
+     * Must be called before [loadUrl]/[loadData]; interfaces added afterward are not visible
+     * to the already-loaded page.
+     */
+    fun jsBridge(name: String, handler: (String) -> Unit) {
+        bridgeNames += name
+        webView.addJavascriptInterface(
+            object {
+                @JavascriptInterface
+                fun post(message: String) {
+                    if (destroyed) return
+                    try {
+                        handler(message)
+                    } catch (t: Throwable) {
+                        reject(t)
+                    }
+                }
+            },
+            name,
+        )
+    }
+
+    /** Loads [url]. Can only be called once per scope. */
+    fun loadUrl(url: String, headers: Map<String, String> = emptyMap()) {
+        markLoaded()
+        webView.loadUrl(url, headers)
+    }
+
+    /** Loads [html] as the page content, with [baseUrl] as its origin. Can only be called once per scope. */
+    fun loadData(baseUrl: String, html: String, mimeType: String = "text/html") {
+        markLoaded()
+        webView.loadDataWithBaseURL(baseUrl, html, mimeType, "UTF-8", null)
+    }
+
+    /** Runs [script], optionally passing its JSON-encoded result to [callback]. */
+    fun evaluateJs(script: String, callback: ((String) -> Unit)? = null) {
+        runOnMain {
+            if (destroyed) return@runOnMain
+            if (callback == null) {
+                webView.evaluateJavascript(script, null)
+            } else {
+                webView.evaluateJavascript(script) { value ->
+                    try {
+                        callback(value)
+                    } catch (t: Throwable) {
+                        reject(t)
+                    }
+                }
+            }
+        }
+    }
+
+    fun stopLoading() {
+        runOnMain {
+            if (!destroyed) {
+                webView.stopLoading()
+            }
+        }
+    }
+
+    /**
+     * Repeats [block] on the main thread every [interval] until [resolve]/[reject] is called or
+     * the scope is destroyed. The first run happens after one [interval], not immediately.
+     */
+    fun poll(interval: Duration = 500.milliseconds, block: () -> Unit) {
+        val runnable = object : Runnable {
+            override fun run() {
+                if (destroyed || deferred.isCompleted) return
+                try {
+                    block()
+                } catch (t: Throwable) {
+                    reject(t)
+                    return
+                }
+                if (!destroyed && !deferred.isCompleted) {
+                    mainHandler.postDelayed(this, interval.inWholeMilliseconds)
+                }
+            }
+        }
+        runOnMain { mainHandler.postDelayed(runnable, interval.inWholeMilliseconds) }
+    }
+
+    private fun markLoaded() {
+        check(loaded.compareAndSet(false, true)) { "load already called on this WebViewScope" }
+    }
+
+    private fun runOnMain(block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            block()
+        } else {
+            mainHandler.post(block)
+        }
+    }
+
+    private fun <V> setting(
+        get: WebSettings.() -> V,
+        set: WebSettings.(V) -> Unit,
+    ): ReadWriteProperty<Any?, V> = object : ReadWriteProperty<Any?, V> {
+        override fun getValue(thisRef: Any?, property: KProperty<*>): V = webView.settings.get()
+
+        override fun setValue(thisRef: Any?, property: KProperty<*>, value: V) {
+            webView.settings.set(value)
+        }
+    }
+}
+
+private class ScopeWebViewClient(
+    private val scope: WebViewScope<*>,
+) : WebViewClient() {
+
+    private val client: OkHttpClient by lazy {
+        Injekt.get<NetworkHelper>().client.newBuilder().apply {
+            interceptors().removeAll { it.javaClass.simpleName == "CloudflareInterceptor" }
+        }.build()
+    }
+
+    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+        if (scope.destroyed) return
+        scope.pageStartedHooks.forEach { it(url.orEmpty()) }
+    }
+
+    override fun onPageFinished(view: WebView?, url: String?) {
+        if (scope.destroyed) return
+        scope.pageFinishedHooks.forEach { it(url.orEmpty()) }
+    }
+
+    override fun shouldInterceptRequest(
+        view: WebView?,
+        request: WebResourceRequest?,
+    ): WebResourceResponse? {
+        if (scope.destroyed || request == null) return null
+        val hooked = scope.interceptHook?.invoke(request)
+        if (hooked != null) return hooked
+        if (scope.useOkHttpNetwork) return fetchFromOkHttp(request)
+        return null
+    }
+
+    private fun fetchFromOkHttp(request: WebResourceRequest): WebResourceResponse? {
+        if (request.method !in NO_BODY_METHODS) return null
+        if (request.url.scheme != "https" && request.url.scheme != "http") return null
+
+        val okhttpRequest = Request.Builder().apply {
+            url(request.url.toString())
+            method(request.method, null)
+            request.requestHeaders.forEach { (key, value) ->
+                if (key == "X-Requested-With" && value == applicationContext.packageName) {
+                    return@forEach
+                }
+                if (key.startsWith("Sec-CH-UA", ignoreCase = true)) {
+                    return@forEach
+                }
+                header(key, value)
+            }
+            clientHints(request.requestHeaders["User-Agent"]).forEach { (key, value) ->
+                header(key, value)
+            }
+        }.build()
+
+        return try {
+            val response = client.newCall(okhttpRequest).execute()
+            val body = response.body
+            val contentType = body.contentType()
+            WebResourceResponse(
+                contentType?.let { "${it.type}/${it.subtype}" } ?: "application/octet-stream",
+                contentType?.charset()?.name() ?: "UTF-8",
+                response.code,
+                response.message.ifEmpty { "OK" },
+                response.headers.toMap()
+                    .filterKeys { !it.equals("Content-Encoding", true) && !it.equals("Content-Length", true) },
+                body.byteStream(),
+            )
+        } catch (_: IOException) {
+            null
+        }
+    }
+
+    private fun clientHints(userAgent: String?): Map<String, String> {
+        userAgent ?: return emptyMap()
+        val (name, version, chromiumVersion) = when {
+            userAgent.contains("Firefox/") && !userAgent.contains("Chrome") -> return emptyMap()
+
+            userAgent.contains("Safari/") &&
+                !userAgent.contains("Chrome") &&
+                !userAgent.contains("Chromium") -> return emptyMap()
+
+            userAgent.contains("Edg/") || userAgent.contains("EdgA/") || userAgent.contains("EdgiOS/") -> {
+                val edgeVersion = EDGE_REGEX.find(userAgent)?.groupValues?.get(1) ?: "134"
+                val chromiumVersion = CHROME_REGEX.find(userAgent)?.groupValues?.get(1) ?: edgeVersion
+                Triple("Microsoft Edge", edgeVersion, chromiumVersion)
+            }
+
+            userAgent.contains("OPR/") -> {
+                val operaVersion = OPERA_REGEX.find(userAgent)?.groupValues?.get(1) ?: "118"
+                val chromiumVersion = CHROME_REGEX.find(userAgent)?.groupValues?.get(1) ?: "134"
+                Triple("Opera", operaVersion, chromiumVersion)
+            }
+
+            userAgent.contains("Chrome/") -> {
+                val chromeVersion = CHROME_REGEX.find(userAgent)?.groupValues?.get(1) ?: "134"
+                Triple("Google Chrome", chromeVersion, chromeVersion)
+            }
+
+            else -> return emptyMap()
+        }
+
+        val isMobile = userAgent.contains("Mobile") ||
+            userAgent.contains("Android") ||
+            userAgent.contains("iPhone") ||
+            userAgent.contains("iPad")
+
+        val platform = when {
+            userAgent.contains("Windows") -> "\"Windows\""
+            userAgent.contains("Android") -> "\"Android\""
+            userAgent.contains("iPhone") || userAgent.contains("iPad") -> "\"iOS\""
+            userAgent.contains("Macintosh") || userAgent.contains("Mac OS X") -> "\"macOS\""
+            userAgent.contains("Linux") -> "\"Linux\""
+            else -> "\"Windows\""
+        }
+
+        return mapOf(
+            "Sec-CH-UA" to "\"$name\";v=\"$version\", \"Chromium\";v=\"$chromiumVersion\", \"Not A(Brand\";v=\"24\"",
+            "Sec-CH-UA-Mobile" to if (isMobile) "?1" else "?0",
+            "Sec-CH-UA-Platform" to platform,
+        )
+    }
+
+    private companion object {
+        val CHROME_REGEX = Regex("""Chrome/(\d+)""")
+        val EDGE_REGEX = Regex("""Edg[^/]*/(\d+)""")
+        val OPERA_REGEX = Regex("""OPR/(\d+)""")
+        val NO_BODY_METHODS = setOf("GET", "HEAD", "OPTIONS")
+    }
+
+    override fun onReceivedError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError?,
+    ) {
+        if (scope.destroyed) return
+        if (request != null && error != null) {
+            scope.receivedErrorHooks.forEach { it(request, error) }
+        }
+    }
+
+    override fun onRenderProcessGone(
+        view: WebView?,
+        detail: RenderProcessGoneDetail?,
+    ): Boolean {
+        scope.destroyed = true
+        scope.renderDead = true
+        scope.reject(RenderProcessGoneException(detail?.didCrash() == true))
+        return true
+    }
+}
+
+private class LoggingWebChromeClient : WebChromeClient() {
+    override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
+        val priority = when (consoleMessage.messageLevel()) {
+            ConsoleMessage.MessageLevel.ERROR -> Log.ERROR
+            ConsoleMessage.MessageLevel.WARNING -> Log.WARN
+            ConsoleMessage.MessageLevel.DEBUG -> Log.DEBUG
+            else -> Log.INFO
+        }
+        Log.println(
+            priority,
+            "KeiyoushiWebView",
+            "${consoleMessage.message()} (${consoleMessage.sourceId()}:${consoleMessage.lineNumber()})",
+        )
+        return true
+    }
+}
+
+/**
+ * Reuses one WebView across multiple [runWebView] calls, destroying it after [idleTimeout]
+ * of inactivity. Concurrent [runWebView] calls sharing a session are serialized via [mutex].
+ * [obtain] and [release] are only ever called on the main thread by [runWebView].
+ */
+class WebViewSession(private val idleTimeout: Duration = 30.seconds) {
+    internal val mutex = Mutex()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var webView: WebView? = null
+    private var destroyTask: Runnable? = null
+
+    internal fun obtain(): WebView {
+        destroyTask?.let(mainHandler::removeCallbacks)
+        destroyTask = null
+        return webView ?: WebView(applicationContext).also { webView = it }
+    }
+
+    internal fun release(dead: Boolean) {
+        val current = webView ?: return
+        if (dead) {
+            current.destroy()
+            webView = null
+            return
+        }
+        current.webViewClient = WebViewClient()
+        current.webChromeClient = null
+        current.loadUrl("about:blank")
+        val task = Runnable {
+            webView?.destroy()
+            webView = null
+            destroyTask = null
+        }
+        destroyTask = task
+        mainHandler.postDelayed(task, idleTimeout.inWholeMilliseconds)
+    }
+
+    /** Immediately destroys the underlying WebView, if any. */
+    fun destroy() {
+        mainHandler.post {
+            destroyTask?.let(mainHandler::removeCallbacks)
+            destroyTask = null
+            webView?.destroy()
+            webView = null
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+private fun setupWebView(webView: WebView) {
+    webView.settings.apply {
+        javaScriptEnabled = true
+        domStorageEnabled = true
+        blockNetworkImage = false
+        useWideViewPort = false
+        loadWithOverviewMode = false
+        userAgentString = null
+    }
+
+    runCatching {
+        val metrics = Resources.getSystem().displayMetrics
+        webView.layoutParams = ViewGroup.LayoutParams(metrics.widthPixels, metrics.heightPixels)
+        webView.measure(
+            View.MeasureSpec.makeMeasureSpec(metrics.widthPixels, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(metrics.heightPixels, View.MeasureSpec.EXACTLY),
+        )
+        webView.layout(0, 0, metrics.widthPixels, metrics.heightPixels)
+    }
+}
+
+/**
+ * Runs a WebView with [configure], suspending until it calls `resolve`/`reject` or [timeout]
+ * elapses. Pass [session] to reuse a WebView across calls instead of spinning up a new one.
+ * The WebView is torn down (or returned to [session]) whether this returns, throws, or is
+ * canceled.
+ */
+suspend fun <T> runWebView(
+    session: WebViewSession? = null,
+    timeout: Duration = 30.seconds,
+    configure: WebViewScope<T>.() -> Unit,
+): T {
+    suspend fun execute(): T = withContext(Dispatchers.Main) {
+        val deferred = CompletableDeferred<T>()
+        val webView = session?.obtain() ?: WebView(applicationContext)
+        setupWebView(webView)
+        val scope = WebViewScope(webView, deferred)
+        webView.webViewClient = ScopeWebViewClient(scope)
+        webView.webChromeClient = LoggingWebChromeClient()
+        try {
+            try {
+                scope.configure()
+            } catch (t: Throwable) {
+                deferred.completeExceptionally(t)
+            }
+            try {
+                withTimeout(timeout) {
+                    deferred.await()
+                }
+            } catch (_: TimeoutCancellationException) {
+                throw WebViewTimeoutException(timeout)
+            }
+        } finally {
+            scope.destroyed = true
+            webView.stopLoading()
+            if (session != null) {
+                scope.bridgeNames.forEach(webView::removeJavascriptInterface)
+                session.release(dead = scope.renderDead)
+            } else {
+                webView.destroy()
+            }
+        }
+    }
+    return session?.mutex?.withLock { execute() } ?: execute()
+}
+
+/**
+ * Blocking wrapper around [runWebView] for non-suspend call sites like OkHttp interceptors.
+ * OkHttp exposes no per-call cancellation callback, so a side coroutine polls
+ * [Call.isCanceled] and cancels the run when it flips. Cancellation surfaces as an
+ * [IOException] (matching how OkHttp itself reports a canceled call to interceptors)
+ * rather than leaking a raw [CancellationException].
+ */
+fun <T> runWebViewBlocking(
+    call: Call,
+    session: WebViewSession? = null,
+    timeout: Duration = 30.seconds,
+    configure: WebViewScope<T>.() -> Unit,
+): T {
+    check(Looper.myLooper() != Looper.getMainLooper()) {
+        "runWebViewBlocking must not be called on the main thread"
+    }
+    return try {
+        runBlocking {
+            val watcher = launch {
+                while (isActive) {
+                    if (call.isCanceled()) {
+                        this@runBlocking.cancel("OkHttp call was canceled")
+                        break
+                    }
+                    delay(250.milliseconds)
+                }
+            }
+            try {
+                runWebView(session, timeout, configure)
+            } finally {
+                watcher.cancel()
+            }
+        }
+    } catch (e: CancellationException) {
+        throw IOException("Canceled", e)
+    }
+}
+
+/**
+ * Reads [key] from `localStorage` after loading [url], or null if unset. Loads an empty
+ * page with [url] as its origin, so [url] itself is never fetched over the network.
+ */
+suspend fun getLocalStorage(url: String, key: String): String? = runWebView(timeout = 10.seconds) {
+    onPageFinished {
+        evaluateJs("localStorage.getItem(${key.toJsonString()})") { value ->
+            resolve(value.parseAs<String?>())
+        }
+    }
+    loadData(url, "")
+}

--- a/core/src/main/kotlin/keiyoushi/zip/Zip.kt
+++ b/core/src/main/kotlin/keiyoushi/zip/Zip.kt
@@ -1,6 +1,7 @@
 package keiyoushi.zip
 
 import eu.kanade.tachiyomi.network.GET
+import keiyoushi.network.get
 import keiyoushi.utils.readLongLittleEndian
 import keiyoushi.utils.readUIntLittleEndian
 import keiyoushi.utils.readUShortLittleEndian
@@ -314,6 +315,17 @@ fun Request.Builder.range(range: LongRange): Request.Builder = header("Range", "
  */
 fun OkHttpClient.zipDirectory(url: String, headers: Headers): ZipDirectory {
     val response = newCall(GET(url, headers).newBuilder().header("Range", "bytes=-$MAX_EOCD_SEARCH").build()).execute()
+    val total = response.header("Content-Range")?.substringAfterLast("/")?.toLongOrNull() ?: throw IOException("Missing or invalid Content-Range")
+    return readZipDirectory(response.body.bytes(), total) { rangeSource(url, headers, it) }
+}
+
+/**
+ * Fetches and parses a remote ZIP's central directory over HTTP range requests.
+ * (Suspend equivalent)
+ */
+suspend fun OkHttpClient.zipDirectoryAsync(url: String, headers: Headers): ZipDirectory {
+    val rangeHeaders = headers.newBuilder().set("Range", "bytes=-$MAX_EOCD_SEARCH").build()
+    val response = this.get(url, rangeHeaders)
     val total = response.header("Content-Range")?.substringAfterLast("/")?.toLongOrNull() ?: throw IOException("Missing or invalid Content-Range")
     return readZipDirectory(response.body.bytes(), total) { rangeSource(url, headers, it) }
 }

--- a/core/translations/strings.json
+++ b/core/translations/strings.json
@@ -2,22 +2,35 @@
   "en": {
     "mirrorTitle": "Preferred Mirror",
     "customUrlTitle": "Custom Base URL",
-    "customUrlDialogMessage": "Leave blank to use the default URL."
+    "customUrlDialogMessage": "Leave blank to use the default URL.",
+    "filterFetchHint": "Tap 'Reset' to load filters"
   },
   "ar": {
     "mirrorTitle": "الخادم البديل المفضل",
     "customUrlTitle": "عنوان أساسي مخصص",
-    "customUrlDialogMessage": "اترك الحقل فارغًا لاستخدام العنوان الافتراضي"
+    "customUrlDialogMessage": "اترك الحقل فارغًا لاستخدام العنوان الافتراضي",
+    "filterFetchHint": "اضغط على 'إعادة تعيين' لتحميل الفلاتر"
+  },
+  "de": {
+    "filterFetchHint": "Tippe auf „Zurücksetzen“, um die Filter zu laden"
   },
   "es": {
     "mirrorTitle": "Dominio preferido",
     "customUrlTitle": "URL base personalizada",
-    "customUrlDialogMessage": "Dejar en blanco para usar la predeterminada"
+    "customUrlDialogMessage": "Dejar en blanco para usar la predeterminada",
+    "filterFetchHint": "Pulse 'Restablecer' para cargar los filtros"
+  },
+  "ja": {
+    "filterFetchHint": "「リセット」をタップしてフィルターを読み込む"
   },
   "ru": {
     "mirrorTitle": "Домен",
     "customUrlTitle": "Домен",
-    "customUrlDialogMessage": "Оставьте пустым, чтобы использовать домен по умолчанию"
+    "customUrlDialogMessage": "Оставьте пустым, чтобы использовать домен по умолчанию",
+    "filterFetchHint": "Нажмите «Сбросить», чтобы загрузить фильтры"
+  },
+  "uk": {
+    "filterFetchHint": "Натисніть «Скинути», щоб завантажити фільтри"
   },
   "vi": {
     "mirrorTitle": "Chọn tên miền",

--- a/ext-bootstrap.py
+++ b/ext-bootstrap.py
@@ -41,6 +41,7 @@ def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser):
     args.path = path
 
     # Validate multisrc theme if provided
+    args.is_keisource = True
     if args.multisrc:
         multisrc_dir = path / "lib-multisrc"
         if not multisrc_dir.exists() or not multisrc_dir.is_dir():
@@ -53,10 +54,133 @@ def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser):
             )
         args.multisrc = multisrc_theme
 
+        if (
+            'libVersion = "1.4"'
+            in (multisrc_dir / multisrc_theme / "build.gradle.kts").read_text()
+        ):
+            args.is_keisource = False
+
 
 def get_ext_classname(extname: str) -> str:
     sanitized = re.sub(r"[^A-Za-z0-9 ]", "", extname)
     return "".join(word.capitalize() for word in re.findall(r"[A-Za-z0-9]+", sanitized))
+
+
+def write_gradle_file(args: argparse.Namespace, ext_dir: Path) -> None:
+    with open(ext_dir / "build.gradle.kts", "w") as f:
+        f.write("import io.github.keiyoushi.gradle.api.ContentWarning\n\n")
+        f.write("plugins {\n")
+        f.write("\talias(kei.plugins.extension)\n")
+        f.write("}\n\n")
+        f.write("keiyoushi {\n")
+        f.write(f'\tname = "{args.extname}"\n')
+
+        if args.multisrc:
+            f.write(f'\ttheme = "{args.multisrc}"\n')
+            f.write("\tversionCode = 0\n")
+        else:
+            f.write("\tversionCode = 1\n")
+
+        f.write(f"\tcontentWarning = ContentWarning.{args.content_warning}\n")
+        f.write("\tlibVersion = ")
+        f.write('"1.6"' if args.is_keisource else '"1.4"')
+        f.write("\n\n")
+
+        f.write("\tsource {\n")
+        if args.source_name:
+            f.write(f'\t\tname = "{args.source_name}"\n')
+
+        f.write(f'\t\tbaseUrl = "{args.baseurl}"\n')
+        f.write(f'\t\tlang = "{args.lang}"\n')
+        f.write("\t}\n")
+
+        if not args.multisrc:
+            f.write("\n\tdeeplink {\n")
+            f.write('\t\tpath("/..*")\n')
+            f.write("\t}\n")
+
+        f.write("}\n")
+
+
+def write_multisrc_source(f, args: argparse.Namespace, classname: str) -> None:
+    multisrc_classname = get_ext_classname(args.multisrc)
+    f.write(
+        f"import eu.kanade.tachiyomi.multisrc.{args.multisrc}.{multisrc_classname}\n"
+    )
+    f.write("import keiyoushi.annotation.Source\n\n")
+    f.write("@Source\n")
+    f.write(f"abstract class {classname} : {multisrc_classname}()\n")
+
+
+def write_keisource_source(f, classname: str) -> None:
+    """Extension stub targeting lib 1.6."""
+    f.write("import eu.kanade.tachiyomi.source.model.FilterList\n")
+    f.write("import eu.kanade.tachiyomi.source.model.MangasPage\n")
+    f.write("import eu.kanade.tachiyomi.source.model.Page\n")
+    f.write("import eu.kanade.tachiyomi.source.model.SChapter\n")
+    f.write("import eu.kanade.tachiyomi.source.model.SManga\n")
+    f.write("import eu.kanade.tachiyomi.source.model.SMangaUpdate\n")
+    f.write("import keiyoushi.annotation.Source\n")
+    f.write("import keiyoushi.source.KeiSource\n")
+    f.write("import okhttp3.HttpUrl\n")
+    f.write("import java.lang.UnsupportedOperationException\n\n")
+
+    f.write("@Source\n")
+    f.write(f"abstract class {classname} : KeiSource() {{\n\n")
+
+    f.write(
+        "\toverride suspend fun getPopularManga(page: Int): MangasPage = throw UnsupportedOperationException()\n\n"
+    )
+    f.write(
+        "\toverride suspend fun getLatestUpdates(page: Int): MangasPage = throw UnsupportedOperationException()\n\n"
+    )
+    f.write(
+        "\toverride suspend fun getSearchMangaList(page: Int, query: String, filters: FilterList): MangasPage =\n"
+        "\t\tthrow UnsupportedOperationException()\n\n"
+    )
+    f.write(
+        "\toverride suspend fun getMangaByUrl(url: HttpUrl): SManga? = throw UnsupportedOperationException()\n\n"
+    )
+
+    f.write("\toverride suspend fun fetchMangaUpdate(\n")
+    f.write("\t\tmanga: SManga,\n")
+    f.write("\t\tchapters: List<SChapter>,\n")
+    f.write("\t\tfetchDetails: Boolean,\n")
+    f.write("\t\tfetchChapters: Boolean,\n")
+    f.write("\t): SMangaUpdate = throw UnsupportedOperationException()\n\n")
+
+    f.write(
+        "\toverride suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = throw UnsupportedOperationException()\n\n"
+    )
+    f.write(
+        "\toverride fun getMangaUrl(manga: SManga): String = throw UnsupportedOperationException()\n\n"
+    )
+    f.write(
+        "\toverride fun getChapterUrl(chapter: SChapter): String = throw UnsupportedOperationException()\n\n"
+    )
+    f.write(
+        "\toverride suspend fun getPageList(chapter: SChapter): List<Page> = throw UnsupportedOperationException()\n"
+    )
+    f.write("}\n")
+
+
+def write_source_file(
+    args: argparse.Namespace,
+    ext_package_dir: Path,
+    ext_dir_lang: str,
+    ext_dir_name: str,
+) -> None:
+    classname = get_ext_classname(args.extname)
+
+    with open(ext_package_dir / f"{classname}.kt", "w") as f:
+        f.write(
+            f"package eu.kanade.tachiyomi.extension.{ext_dir_lang}.{ext_dir_name}\n\n"
+        )
+
+        if args.multisrc:
+            write_multisrc_source(f, args, classname)
+        else:
+            write_keisource_source(f, classname)
 
 
 if __name__ == "__main__":
@@ -88,7 +212,7 @@ if __name__ == "__main__":
     argparser.add_argument(
         "-c",
         "--content-warning",
-        choices=["SAFE", "MIXED", "NSFW"],
+        choices=("SAFE", "MIXED", "NSFW"),
         type=str.upper,
         default="SAFE",
         help="Content warning level",
@@ -121,36 +245,7 @@ if __name__ == "__main__":
     ext_dir.mkdir(parents=True)
     print(f"Created extension directory: '{ext_dir}'")
 
-    with open(ext_dir / "build.gradle.kts", "w") as f:
-        f.write("import io.github.keiyoushi.gradle.api.ContentWarning\n\n")
-        f.write("plugins {\n")
-        f.write("\talias(kei.plugins.extension)\n")
-        f.write("}\n\n")
-        f.write("keiyoushi {\n")
-        f.write(f'\tname = "{args.extname}"\n')
-
-        if args.multisrc:
-            f.write(f'\ttheme = "{args.multisrc}"\n')
-            f.write("\tversionCode = 0\n")
-        else:
-            f.write("\tversionCode = 1\n")
-
-        f.write(f"\tcontentWarning = ContentWarning.{args.content_warning}\n")
-        f.write('\tlibVersion = "1.4"\n\n')
-
-        f.write("\tsource {\n")
-        if args.source_name:
-            f.write(f'\t\tname = "{args.source_name}"\n')
-        f.write(f'\t\tlang = "{args.lang}"\n')
-        f.write(f'\t\tbaseUrl = "{args.baseurl}"\n')
-        f.write("\t}\n")
-
-        if not args.multisrc:
-            f.write("\n\tdeeplink {\n")
-            f.write('\t\tpath("/..*")\n')
-            f.write("\t}\n")
-
-        f.write("}\n")
+    write_gradle_file(args, ext_dir)
 
     ext_package_dir = (
         ext_dir
@@ -165,110 +260,5 @@ if __name__ == "__main__":
     ext_package_dir.mkdir(parents=True)
     print(f"Created extension package directory: '{ext_package_dir}'")
 
-    with open(ext_package_dir / f"{get_ext_classname(args.extname)}.kt", "w") as f:
-        f.write(
-            f"""package eu.kanade.tachiyomi.extension.{ext_dir_lang}.{ext_dir_name}\n\n"""
-        )
-
-        if args.multisrc:
-            f.write(
-                f"import eu.kanade.tachiyomi.multisrc.{args.multisrc}.{get_ext_classname(args.multisrc)}\n"
-            )
-            f.write("import keiyoushi.annotation.Source\n\n")
-            f.write("@Source\n")
-            f.write(
-                f"abstract class {get_ext_classname(args.extname)} : {get_ext_classname(args.multisrc)}()\n"
-            )
-        else:
-            f.write("import eu.kanade.tachiyomi.source.model.FilterList\n")
-            f.write("import eu.kanade.tachiyomi.source.model.MangasPage\n")
-            f.write("import eu.kanade.tachiyomi.source.model.Page\n")
-            f.write("import eu.kanade.tachiyomi.source.model.SChapter\n")
-            f.write("import eu.kanade.tachiyomi.source.model.SManga\n")
-            f.write("import eu.kanade.tachiyomi.source.online.HttpSource\n")
-            f.write("import keiyoushi.annotation.Source\n")
-            f.write("import okhttp3.Request\n")
-            f.write("import okhttp3.Response\n")
-            f.write("import rx.Observable\n")
-            f.write("import java.lang.UnsupportedOperationException\n\n")
-
-            f.write("@Source\n")
-            f.write(
-                f"abstract class {get_ext_classname(args.extname)} : HttpSource() {{\n\n"
-            )
-            f.write("\toverride val supportsLatest = true\n\n")
-            f.write("\toverride val client = network.client\n\n")
-
-            f.write("\toverride fun headersBuilder() = super.headersBuilder()\n")
-            f.write('\t\t.set("Referer", "$baseUrl/")\n\n')
-
-            f.write(
-                "\toverride fun popularMangaRequest(page: Int): Request = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun popularMangaParse(response: Response): MangasPage = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun latestUpdatesParse(response: Response): MangasPage = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {\n"
-            )
-            f.write('\t\tif (query.startsWith("https://")) {\n')
-            f.write('\t\t\tthrow Exception("Deeplink not implemented")\n')
-            f.write("\t\t}\n\n")
-            f.write("\t\treturn super.fetchSearchManga(page, query, filters)\n")
-            f.write("\t}\n\n")
-
-            f.write(
-                "\toverride fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun searchMangaParse(response: Response): MangasPage = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun mangaDetailsRequest(manga: SManga): Request = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun getMangaUrl(manga: SManga): String = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun mangaDetailsParse(response: Response): SManga = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun chapterListRequest(manga: SManga): Request = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun chapterListParse(response: Response): List<SChapter> = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun pageListRequest(chapter: SChapter): Request = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun getChapterUrl(chapter: SChapter): String = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun pageListParse(response: Response): List<Page> = throw UnsupportedOperationException()\n\n"
-            )
-
-            f.write(
-                "\toverride fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()\n"
-            )
-
-            f.write("}\n")
+    write_source_file(args, ext_package_dir, ext_dir_lang, ext_dir_name)
+    print(f"Created source file: '{ext_package_dir}'")

--- a/gradle/build-logic/src/main/kotlin/ExtensionPlugin.kt
+++ b/gradle/build-logic/src/main/kotlin/ExtensionPlugin.kt
@@ -26,7 +26,6 @@ import io.github.keiyoushi.gradle.tasks.GenerateKeepRulesTask
 import io.github.keiyoushi.gradle.tasks.GenerateManifestTask
 import io.github.keiyoushi.gradle.tasks.GenerateSourceInfoTask
 import io.github.keiyoushi.gradle.tasks.SignExtensionJarTask
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -297,6 +296,8 @@ class ExtensionPlugin : Plugin<Project> {
             val sourceInfoJsonProvider = versionCodeProvider.zip(versionNameProvider) { code, name ->
                 Json.encodeToString(
                     ExtensionMetadata(
+                        module = applicationIdSuffix,
+                        theme = keiyoushi.theme.orNull,
                         packageName = packageName,
                         name = extName,
                         versionCode = code,

--- a/gradle/build-logic/src/main/kotlin/ExtensionPlugin.kt
+++ b/gradle/build-logic/src/main/kotlin/ExtensionPlugin.kt
@@ -250,6 +250,7 @@ class ExtensionPlugin : Plugin<Project> {
             addProvider("implementation", keiyoushi.theme.map { project(":lib-multisrc:$it") })
             implementation(project(":core"))
             compileOnly(libs.bundles.common)
+            compileOnly(keiyoushi.libVersion.flatMap { if (it == "1.6") libs.tachiyomi.lib.v16 else libs.tachiyomi.lib.v14 })
             ksp(project(":compiler"))
         }
 
@@ -289,18 +290,24 @@ class ExtensionPlugin : Plugin<Project> {
                     mirrorUrls = source.baseUrl.mirrors.map { it.url },
                 )
             }
-            val extensionInfo = ExtensionMetadata(
-                packageName = packageName,
-                name = extName,
-                versionCode = versionCodeProvider.get(),
-                versionName = versionNameProvider.get(),
-                extensionLib = keiyoushi.libVersion.get(),
-                // Proto keiyoushi.gradle.api.ContentWarning: UNSPECIFIED=0, SAFE=1, MIXED=2, NSFW=3 (enum ordinal + 1).
-                contentWarning = keiyoushi.contentWarning.get().ordinal + 1,
-                sources = sourceInfos,
-            )
-            val sourceInfoJson = Json.encodeToString(extensionInfo)
-            sourceInfoTask.configure { content.set(sourceInfoJson) }
+            // Proto keiyoushi.gradle.api.ContentWarning: UNSPECIFIED=0, SAFE=1, MIXED=2, NSFW=3 (enum ordinal + 1).
+            val contentWarningOrdinal = keiyoushi.contentWarning.get().ordinal + 1
+            val libVersionValue = keiyoushi.libVersion.get()
+
+            val sourceInfoJsonProvider = versionCodeProvider.zip(versionNameProvider) { code, name ->
+                Json.encodeToString(
+                    ExtensionMetadata(
+                        packageName = packageName,
+                        name = extName,
+                        versionCode = code,
+                        versionName = name,
+                        extensionLib = libVersionValue,
+                        contentWarning = contentWarningOrdinal,
+                        sources = sourceInfos,
+                    ),
+                )
+            }
+            sourceInfoTask.configure { content.set(sourceInfoJsonProvider) }
             tasks.named("assembleRelease").configure { dependsOn(sourceInfoTask) }
 
             tasks.withType<PackageAndroidArtifact>().configureEach {

--- a/gradle/build-logic/src/main/kotlin/ExtensionPlugin.kt
+++ b/gradle/build-logic/src/main/kotlin/ExtensionPlugin.kt
@@ -194,9 +194,13 @@ class ExtensionPlugin : Plugin<Project> {
                 variant.sources.manifests.addStaticManifestFile("AndroidManifest.xml")
                 variant.sources.manifests.addGeneratedManifestFile(manifestTask) { it.outputFile }
 
+                val filenameProvider = versionNameProvider.map { "tachiyomi-$applicationIdSuffix-v$it" }
+
                 variant.outputs.forEach { output ->
                     output.versionCode.set(versionCodeProvider)
                     output.versionName.set(versionNameProvider)
+                    @Suppress("UnstableApiUsage")
+                    output.outputFileName.set(filenameProvider.map { "$it.apk" })
                 }
 
                 if (variant.buildType == "release") {
@@ -207,15 +211,12 @@ class ExtensionPlugin : Plugin<Project> {
                     val createTask = tasks.register<CreateExtensionJarTask>("create${variantName}ExtensionJar") {
                         libraryClasspath.from(externalLibs, bootClasspath)
                         proguardConfigFile.set(layout.buildDirectory.file("outputs/mapping/${variant.name}/configuration.txt"))
-                        @Suppress("UnstableApiUsage")
                         manifestFile.set(variant.artifacts.get(SingleArtifact.MERGED_MANIFEST))
-                        @Suppress("UnstableApiUsage")
                         apkDir.set(variant.artifacts.get(SingleArtifact.APK))
                         proguardClasspath.from(proguardConfiguration)
                         outputJar.set(layout.buildDirectory.file("intermediates/extension_jar/${variant.name}/unsigned.jar"))
                     }
 
-                    @Suppress("UnstableApiUsage")
                     variant.artifacts.forScope(ScopedArtifacts.Scope.ALL)
                         .use(createTask)
                         .toGet(
@@ -231,18 +232,13 @@ class ExtensionPlugin : Plugin<Project> {
                         keyAlias.set(signingConfig.keyAlias.orEmpty())
                         keyPassword.set(signingConfig.keyPassword.orEmpty())
                         minSdkVersion.set(kei.versions.android.sdk.min.map { it.toInt() })
-                        val jarName = versionNameProvider.map { "tachiyomi-$applicationIdSuffix-v$it.jar" }
-                        outputJar.set(layout.buildDirectory.file(jarName.map { "outputs/jar/${variant.name}/$it" }))
+                        outputJar.set(layout.buildDirectory.file(filenameProvider.map { "outputs/jar/${variant.name}/$it.jar" }))
                     }
 
                     tasks.matching { it.name == "assemble$variantName" }
                         .configureEach { dependsOn(signTask) }
                 }
             }
-        }
-
-        base {
-            archivesName.set(versionNameProvider.map { "tachiyomi-$applicationIdSuffix-v$it" })
         }
 
         dependencies {
@@ -348,9 +344,5 @@ private fun Project.android(block: ApplicationExtension.() -> Unit) {
 }
 
 private fun Project.androidComponents(block: ApplicationAndroidComponentsExtension.() -> Unit) {
-    extensions.configure(block)
-}
-
-private fun Project.base(block: BasePluginExtension.() -> Unit) {
     extensions.configure(block)
 }

--- a/gradle/build-logic/src/main/kotlin/LibraryPlugin.kt
+++ b/gradle/build-logic/src/main/kotlin/LibraryPlugin.kt
@@ -40,6 +40,7 @@ class LibraryPlugin : Plugin<Project> {
 
         dependencies {
             compileOnly(libs.bundles.common)
+            compileOnly(libs.tachiyomi.lib.v16)
             implementation(project(":core"))
         }
     }

--- a/gradle/build-logic/src/main/kotlin/ThemePlugin.kt
+++ b/gradle/build-logic/src/main/kotlin/ThemePlugin.kt
@@ -44,6 +44,7 @@ class ThemePlugin : Plugin<Project> {
 
         dependencies {
             compileOnly(libs.bundles.common)
+            compileOnly(keiyoushi.libVersion.flatMap { if (it == "1.6") libs.tachiyomi.lib.v16 else libs.tachiyomi.lib.v14 })
             implementation(project(":core"))
         }
 

--- a/gradle/build-logic/src/main/kotlin/io/github/keiyoushi/gradle/internal/Constant.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/keiyoushi/gradle/internal/Constant.kt
@@ -1,3 +1,3 @@
 package io.github.keiyoushi.gradle.internal
 
-internal val VALID_LIB_VERSIONS = listOf("1.4")
+internal val VALID_LIB_VERSIONS = listOf("1.4", "1.6")

--- a/gradle/build-logic/src/main/kotlin/io/github/keiyoushi/gradle/internal/MetadataModels.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/keiyoushi/gradle/internal/MetadataModels.kt
@@ -7,6 +7,8 @@ internal data class ResolvedSource(val name: String, val lang: String, val id: L
 
 @Serializable
 internal data class ExtensionMetadata(
+    val module: String,
+    val theme: String?,
     val packageName: String,
     val name: String,
     val versionCode: Int,

--- a/gradle/build-logic/src/main/kotlin/io/github/keiyoushi/gradle/internal/extensions/DependencyHandlerScope.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/keiyoushi/gradle/internal/extensions/DependencyHandlerScope.kt
@@ -11,7 +11,12 @@ internal fun DependencyHandlerScope.api(dependencyNotation: Provider<MinimalExte
     add("api", dependencyNotation)
 }
 
+@JvmName("compileOnlyBundle")
 internal fun DependencyHandlerScope.compileOnly(dependencyNotation: Provider<ExternalModuleDependencyBundle>) {
+    add("compileOnly", dependencyNotation)
+}
+
+internal fun DependencyHandlerScope.compileOnly(dependencyNotation: Provider<MinimalExternalModuleDependency>) {
     add("compileOnly", dependencyNotation)
 }
 

--- a/gradle/kei.versions.toml
+++ b/gradle/kei.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Used in [/gradle/build-logic/src/main/kotlin/AndroidBasePlugin.kt]
-android-sdk-min = "21"
+android-sdk-min = "26"
 android-sdk-compile = "37"
 android-sdk-target = "37"
 java = "11"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,10 @@ okhttp-brotli = { module = "com.squareup.okhttp3:okhttp-brotli", version.ref = "
 okhttp-zstd = { module = "com.squareup.okhttp3:okhttp-zstd", version.ref = "okhttp" }
 quickjs = { module = "com.github.zhanghai.quickjs-java:quickjs-android", version = "547f5b1597" }
 rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
-tachiyomi-lib = { module = "com.github.keiyoushi:extensions-lib", version = "18a8e26be2" }
+#noinspection SimilarGradleDependency
+tachiyomi-lib-v14 = { module = "com.github.keiyoushi:extensions-lib", version = "18a8e26be2" }
+#noinspection SimilarGradleDependency
+tachiyomi-lib-v16 = { module = "com.github.keiyoushi:extensions-lib", version = "6e0c96cea8" }
 
 # Required by Kotlin 2.x compiler to resolve type-use annotations (e.g. org.jspecify.annotations.Nullable) used in Jsoup's API signatures
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
@@ -55,4 +58,4 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
 [bundles]
-common = ["kotlin-stdlib", "coroutines-core", "coroutines-android", "injekt-core", "rxjava", "kotlin-protobuf", "kotlin-json", "kotlin-json-okio", "jsoup", "jspecify", "okhttp-core", "okhttp-brotli", "okhttp-zstd", "zstd-kmp-okio", "tachiyomi-lib", "quickjs"]
+common = ["kotlin-stdlib", "coroutines-core", "coroutines-android", "injekt-core", "rxjava", "kotlin-protobuf", "kotlin-json", "kotlin-json-okio", "jsoup", "jspecify", "okhttp-core", "okhttp-brotli", "okhttp-zstd", "zstd-kmp-okio", "quickjs"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android-gradle = "9.2.1"
-coroutines = "1.11.0"
+coroutines = "1.10.2"
 serialization = "1.7.3"
 junit = "4.13.2"
 kotlin-gradle = "2.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-android-gradle = "9.2.1"
-coroutines = "1.10.2"
-serialization = "1.7.3"
+android-gradle = "9.3.1"
+coroutines = "1.11.0"
+serialization = "1.11.0"
 junit = "4.13.2"
-kotlin-gradle = "2.4.0"
+kotlin-gradle = "2.4.10"
 ksp = "2.3.9"
 kotlinpoet = "2.3.0"
 ktlint = "1.8.0"

--- a/lib/textinterceptor/src/keiyoushi/lib/textinterceptor/TextInterceptor.kt
+++ b/lib/textinterceptor/src/keiyoushi/lib/textinterceptor/TextInterceptor.kt
@@ -1,12 +1,10 @@
 package keiyoushi.lib.textinterceptor
 
-import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Typeface
 import android.net.Uri
-import android.os.Build
 import android.text.Html
 import android.text.Layout
 import android.text.StaticLayout
@@ -110,13 +108,7 @@ class TextInterceptor : Interceptor {
             .build()
     }
 
-    @SuppressLint("ObsoleteSdkInt")
-    private fun textFixer(htmlString: String): String = if (Build.VERSION.SDK_INT >= 24) {
-        Html.fromHtml(htmlString, Html.FROM_HTML_MODE_LEGACY).toString()
-    } else {
-        @Suppress("DEPRECATION")
-        Html.fromHtml(htmlString).toString()
-    }
+    private fun textFixer(htmlString: String): String = Html.fromHtml(htmlString, Html.FROM_HTML_MODE_LEGACY).toString()
 
     @Suppress("SameParameterValue")
     private fun StaticLayout.draw(canvas: Canvas, x: Float, y: Float) {


### PR DESCRIPTION
## Summary by Sourcery

Introduce KeiSource as the new suspend-based extension base class and migrate tooling, docs, and scaffolding to use libVersion 1.6, plus improve networking, WebView, ZIP, and publishing infrastructure.

New Features:
- Add KeiSource as the primary base class for new extensions and multisrc themes, providing a suspend-based API and automatic filter fetching and caching.
- Add WebView utilities (runWebView, WebViewSession, getLocalStorage, WebView intercept helpers) for browser-like execution inside sources.
- Add async ZIP directory helper and enhanced rate limiting and cache control interceptors for HTTP clients.

Enhancements:
- Update CONTRIBUTING and agent guidelines to document KeiSource usage, HTTP/WebView helpers, date parsing best practices, and new extension scaffolding conventions.
- Revise ext-bootstrap.py to scaffold new non-multisrc extensions as KeiSource-based with libVersion 1.6, while respecting legacy multisrc themes still on 1.4.
- Adjust build logic to support both libVersion 1.4 and 1.6, wire the appropriate Tachiyomi extension library per version, and generate deterministic source-info JSON and index.pb.
- Simplify icon handling and URLs in the publish script by reading icons from the source tree instead of extracting them from APKs, and drop the legacy JSON index.
- Tighten ProGuard/R8 rules to allow shrinking/optimization/obfuscation of injected FullTypeReference classes and re-enable optimization.
- Raise the minimum Android SDK to 26 and bump core Gradle, Kotlin, and kotlinx.serialization versions.
- Streamline TextInterceptor HTML handling by using the modern Html.fromHtml API unconditionally and minor utility cleanups.

Build:
- Update Gradle plugin versions, Kotlin Gradle plugin, and serialization library versions, and adjust dependency bundles to separate v1.4 and v1.6 Tachiyomi extension libs.
- Extend build logic for extensions, themes, and libraries to compile against the correct Tachiyomi lib based on libVersion and to generate versioned APK/JAR filenames and enriched metadata.
- Allow both 1.4 and 1.6 as valid libVersion values in the Gradle DSL and raise the configured minimum Android SDK.

Deployment:
- Change the published icon base URL to point to the cursed-manga-extensions repo and compute icon URLs from module or theme resources instead of storing extracted icons in the repo.
- Switch the public repo index from a legacy JSON endpoint to a gzipped protobuf index.pb and ensure deterministic serialization.

Documentation:
- Expand CONTRIBUTING.md with guidance on KeiSource, HTTP helpers, WebView usage, date parsing via java.time/Instant, filter fetching, and updated libVersion semantics for extensions and themes.
- Add AGENTS.md with explicit instructions for AI agents working on this repo, emphasizing KeiSource, KSP metadata injection, DSL-driven config, and code style expectations.
- Update README.md to reference the new protobuf-based index URL instead of the old JSON index.