### PR TITLE
fix(ehentai): retry malformed image responses

### DIFF
--- a/src/all/ehentai/build.gradle.kts
+++ b/src/all/ehentai/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 keiyoushi {
     name = "E-Hentai"
-    versionCode = 29
+    versionCode = 30
     contentWarning = ContentWarning.NSFW
     libVersion = "1.4"
 

--- a/src/all/ehentai/src/eu/kanade/tachiyomi/extension/all/ehentai/EHentai.kt
+++ b/src/all/ehentai/src/eu/kanade/tachiyomi/extension/all/ehentai/EHentai.kt
@@ -410,6 +410,14 @@ abstract class EHentai :
         return "$imgUrl#$bakUrl"
     }
 
+    private fun Response.hasValidImageHeader(): Boolean {
+        val header = peekBody(IMAGE_HEADER_SIZE).bytes()
+        return IMAGE_SIGNATURES.any { header.startsWith(it) } ||
+            (header.startsWith(RIFF_SIGNATURE) && header.startsWith(WEBP_SIGNATURE, 8))
+    }
+
+    private fun ByteArray.startsWith(signature: ByteArray, offset: Int = 0): Boolean = size >= offset + signature.size && signature.indices.all { this[offset + it] == signature[it] }
+
     private val cookiesHeader by lazy {
         val cookies = mutableMapOf<String, String>()
 
@@ -461,8 +469,12 @@ abstract class EHentai :
             val bakUrl = request.url.fragment
                 ?: return@addInterceptor result.getOrThrow()
 
-            if (result.isFailure || result.getOrNull()?.isSuccessful != true) {
-                result.getOrNull()?.close()
+            val response = result.getOrNull()
+            val isUsableImage = response?.isSuccessful == true &&
+                runCatching { response.hasValidImageHeader() }.getOrDefault(false)
+
+            if (!isUsableImage) {
+                response?.close()
                 val newRequest = GET(bakUrl, headers)
                 val newImageUrl = imageUrlParse(chain.proceed(newRequest), false)
                 val newImageRequest = request.newBuilder()
@@ -640,6 +652,16 @@ abstract class EHentai :
         const val QUERY_PREFIX = "?f_apply=Apply+Filter"
         const val PREFIX_ID_SEARCH = "id:"
         const val TR_SUFFIX = "TR"
+
+        private const val IMAGE_HEADER_SIZE = 12L
+        private val IMAGE_SIGNATURES = listOf(
+            byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()),
+            byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A),
+            "GIF87a".toByteArray(),
+            "GIF89a".toByteArray(),
+        )
+        private val RIFF_SIGNATURE = "RIFF".toByteArray()
+        private val WEBP_SIGNATURE = "WEBP".toByteArray()
 
         // Preferences vals
         private const val ENFORCE_LANGUAGE_PREF_KEY = "ENFORCE_LANGUAGE"


### PR DESCRIPTION
E-Hentai can return HTTP 200 responses with malformed image payloads, causing the existing nl fallback to be skipped and corrupt files to be saved.

Validate a small image header prefix and retry through the nl alternate image page when the payload is invalid.

Checklist:

- [x] Updated `versionCode` value in `build.gradle.kts`
- [x] Updated `baseVersionCode` in `build.gradle.kts` (if updated multisrc theme code) — N/A
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Set the `contentWarning` configuration in `build.gradle.kts` appropriately
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed — N/A
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension — N/A
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

## Summary by Sourcery

Validate E-Hentai image responses and fall back to the backup URL when the payload is malformed.

Bug Fixes:
- Detect malformed image payloads despite HTTP 200 responses and retry using the alternate image page to avoid saving corrupt files.

Enhancements:
- Add lightweight image header signature checks for common formats (JPEG, PNG, GIF, WEBP) to verify response validity before use.

Build:
- Bump the E-Hentai extension versionCode to 30.